### PR TITLE
feat: Phase 3 Llada2DefaultRemaskingPolicy (issue #7)

### DIFF
--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -79,6 +79,11 @@ against `vllm_dllm_plugin.config.DRAFT_SIZE` only. If the stack ever uses a
 per-request block length, this helper must gain an explicit length parameter (or
 a replacement); otherwise it becomes misleading.
 
+**LLaDA2 default policy (`Llada2DefaultRemaskingPolicy`, issue #7):** optional
+`remasking_config` keys `commit_confidence_threshold` (float) and `mask_token_id`
+(int); defaults in `vllm_dllm_plugin.config`. See module docstring in
+`vllm_dllm_plugin.remasking.llada2_default`.
+
 ## See also
 
 - `docs/DESIGN_MVP.md` sections 6-8 (canonical diagrams and tables)

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -86,10 +86,14 @@ per-request block length, this helper must gain an explicit length parameter (or
 a replacement); otherwise it becomes misleading.
 
 **LLaDA2 default policy (`Llada2DefaultRemaskingPolicy`, issue #7):** optional
-`remasking_config` keys: `commit_confidence_threshold` (float), `mask_token_id`
-(int), `denoise_steps` (int), `denoise_step_index` (int), `num_transfer` (int
-override). Defaults in `vllm_dllm_plugin.config`. See module docstring in
-`vllm_dllm_plugin.remasking.llada2_default`.
+`remasking_config` keys: `commit_confidence_threshold` (float; a masked position
+counts as **high-confidence** only when softmax probability at the argmax token
+is **strictly greater** than this value — the same comparator as Hugging Face
+Diffusers [`BlockRefinementScheduler.step`](https://github.com/huggingface/diffusers/blob/main/src/diffusers/schedulers/scheduling_block_refinement.py)),
+`mask_token_id` (int), `denoise_steps` (int), `denoise_step_index` (int),
+`num_transfer` (int override of the per-step transfer budget; **not** in the
+Diffusers API, for tests and tooling). Defaults in `vllm_dllm_plugin.config`. See
+module docstring in `vllm_dllm_plugin.remasking.llada2_default`.
 
 ## See also
 

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -33,6 +33,12 @@ If no tokens are committed in a step, the plugin scheduler rolls back
 **`DRAFT_SIZE`**). See `DESIGN_MVP.md` section 6 (sequence diagram) and section 1
 (Commit-0 goal).
 
+**dLLM default remasking:** `Llada2DefaultRemaskingPolicy` may return **empty**
+`committed_token_ids` on inner denoise steps while the draft still contains the
+configured mask token. That is **not** a failed step; the worker must not surface
+those inner steps to commit-0 without an explicit contract exception, or it must
+batch the inner loop into one engine step (see `DESIGN_MVP.md` section 6).
+
 ## Mutual exclusion
 
 True speculative decoding on the same requests must **not** be combined with the
@@ -58,7 +64,7 @@ DllmScheduler -> DllmScheduler: spec_token_ids := next block
 
 ## Remasking handoff (section 8)
 
-`RemaskingPolicy.apply` consumes the current **input block** and model outputs,
+`RemaskingPolicy.apply` consumes the current **input draft** (`input_draft`) and model outputs,
 and returns **committed** ids plus a **fixed-length** next input block
 (`RemaskStepResult` from `vllm_dllm_plugin.remasking`). Length of
 `next_input_block` must equal **`DRAFT_SIZE`**. The dataclass does not enforce
@@ -80,8 +86,9 @@ per-request block length, this helper must gain an explicit length parameter (or
 a replacement); otherwise it becomes misleading.
 
 **LLaDA2 default policy (`Llada2DefaultRemaskingPolicy`, issue #7):** optional
-`remasking_config` keys `commit_confidence_threshold` (float) and `mask_token_id`
-(int); defaults in `vllm_dllm_plugin.config`. See module docstring in
+`remasking_config` keys: `commit_confidence_threshold` (float), `mask_token_id`
+(int), `denoise_steps` (int), `denoise_step_index` (int), `num_transfer` (int
+override). Defaults in `vllm_dllm_plugin.config`. See module docstring in
 `vllm_dllm_plugin.remasking.llada2_default`.
 
 ## See also

--- a/docs/DESIGN_MVP.md
+++ b/docs/DESIGN_MVP.md
@@ -129,7 +129,7 @@ sequenceDiagram
   DllmSched->>DllmSched: schedule read spec_token_ids
   DllmSched->>DllmSched: set scheduled_spec_decode_tokens num_scheduled_tokens equals DRAFT_SIZE
   Engine->>DllmWork: SchedulerOutput
-  DllmWork->>DllmWork: build batch from input block
+  DllmWork->>DllmWork: build batch from input draft
   DllmWork->>Model: forward one block plus KV context
   Model->>Remask: logits or per-position scores
   Remask->>DllmWork: committed_token_ids zero_to_DRAFT_SIZE
@@ -144,6 +144,8 @@ sequenceDiagram
 
 **Commit-0:** In `update_from_output`, if `sampled_token_ids` is empty for a request, the scheduler rolls back `num_computed_tokens` by the number of tokens scheduled that step (typically `DRAFT_SIZE` in this MVP design).
 
+**dLLM inner denoise:** `Llada2DefaultRemaskingPolicy` intentionally returns **empty** `committed_token_ids` on every step while the output draft still contains the mask token; only when the block is fully unmasked does it return the full `DRAFT_SIZE` tuple and an all-mask `next_input_block` for the next block. That means empty commits are **expected** during in-block refinement. `DllmWorker` (issue #10) must either complete the inner denoise loop **before** emitting one engine step, or the stack defines an explicit exception to commit-0 for this mode so the scheduler does not roll back mid-block.
+
 ---
 
 ## 7. Field mapping (MVP contract)
@@ -151,7 +153,7 @@ sequenceDiagram
 | vLLM field / API | Role when plugin stack is active |
 |------------------|----------------------------------|
 | `Request.spec_token_ids` | **Next-step input block** (length `DRAFT_SIZE`) for the upcoming schedule. |
-| `SchedulerOutput.scheduled_spec_decode_tokens` | **Input block** (length `DRAFT_SIZE`) for this step’s forward. |
+| `SchedulerOutput.scheduled_spec_decode_tokens` | **Input draft** / block (length `DRAFT_SIZE`) for this step’s forward; aligns with `RemaskingPolicy.apply(..., input_draft=...)`. |
 | `SchedulerOutput.num_scheduled_tokens` (per request) | Set to `DRAFT_SIZE` for decode steps using the block path. |
 | `ModelRunnerOutput.sampled_token_ids` | **Committed** token IDs only, length 0..`DRAFT_SIZE` (may be empty). |
 | Worker `take_draft_token_ids()` | Returns **next-step input block** packaged as `DraftTokenIds` for engine → scheduler. |
@@ -181,7 +183,7 @@ flowchart TB
 
 **MVP contract (conceptual):**
 
-- **Input:** Current input block, logits (or equivalent), optional request config (e.g. threshold).
+- **Input:** Current **input draft** (`input_draft` on `RemaskingPolicy.apply`), logits (or equivalent), optional request config (threshold, mask id, denoise step index, etc.).
 - **Output:** `committed_token_ids: list[int]` (0..N), `next_input_block: list[int]` (length `DRAFT_SIZE`), and internal mask/draft state for logging.
 
 **Shape checks:** `RemaskStepResult` (see `vllm_dllm_plugin.remasking`) does not validate lengths at construction. After `RemaskingPolicy.apply`, the worker or policy boundary should run `validate_remask_step_result()` (same package) or the concrete policy should raise `ValueError` for invalid shapes, consistent with the protocol docstring on `apply`.
@@ -190,7 +192,7 @@ flowchart TB
 
 **Protocol runtime checks:** `RemaskingPolicy` is `@runtime_checkable`; `isinstance(obj, RemaskingPolicy)` only checks for a callable `apply`, not full signature compliance or return types. Use tests and static typing for the real contract.
 
-**LLaDA2.0 default** is `vllm_dllm_plugin.remasking.llada2_default.Llada2DefaultRemaskingPolicy` (softmax confidence on the per-position argmax vs threshold, remask with `mask_token_id`; issue #7). Optional `remasking_config` keys and defaults are summarized in `docs/CONTRACTS.md`. Additional policies can plug in as new `RemaskingPolicy` implementations without changing the worker’s engine contract.
+**LLaDA2.0 default** is `vllm_dllm_plugin.remasking.llada2_default.Llada2DefaultRemaskingPolicy` (issue #7): per-position argmax and softmax probability at that token; only **mask** positions join confidence-based transfers; decoded positions are preserved; a **transfer-count schedule** over `denoise_steps` (or a `num_transfer` override) combines **inclusive** thresholding (`confidence >= commit_confidence_threshold`) with a top‑k fallback on masked positions when too few meet the threshold. While the output draft still contains `mask_token_id`, `committed_token_ids` is **empty** and progress is carried in `next_input_block`; when no mask remains, the policy returns the full decoded block as `committed_token_ids` and sets `next_input_block` to an all-mask draft for the following block. Optional `remasking_config` keys and defaults are summarized in `docs/CONTRACTS.md`. Additional policies can plug in as new `RemaskingPolicy` implementations without changing the worker’s engine contract.
 
 ---
 

--- a/docs/DESIGN_MVP.md
+++ b/docs/DESIGN_MVP.md
@@ -190,7 +190,7 @@ flowchart TB
 
 **Protocol runtime checks:** `RemaskingPolicy` is `@runtime_checkable`; `isinstance(obj, RemaskingPolicy)` only checks for a callable `apply`, not full signature compliance or return types. Use tests and static typing for the real contract.
 
-**LLaDA2.0 default** implements one concrete policy (e.g. confidence-based commit + remask rest); additional policies can plug in as new `RemaskingPolicy` implementations without changing the worker’s engine contract.
+**LLaDA2.0 default** is `vllm_dllm_plugin.remasking.llada2_default.Llada2DefaultRemaskingPolicy` (softmax confidence on the per-position argmax vs threshold, remask with `mask_token_id`; issue #7). Optional `remasking_config` keys and defaults are summarized in `docs/CONTRACTS.md`. Additional policies can plug in as new `RemaskingPolicy` implementations without changing the worker’s engine contract.
 
 ---
 

--- a/docs/DESIGN_MVP.md
+++ b/docs/DESIGN_MVP.md
@@ -11,7 +11,7 @@ This document describes the **MVP architecture** for [`vllm-project/dllm-plugin`
 | Goal | Notes |
 |------|--------|
 | **One diffusion step = one worker schedule = one model forward** | Same abstraction as in that discussion; continuous batching stays aligned across requests. |
-| **Block size `DRAFT_SIZE`** | Fixed per model (e.g. 32 for LLaDA2.0); one input block in, variable **Committed** (0..DRAFT_SIZE) + fixed **next-step input block** out. |
+| **Block size `DRAFT_SIZE`** | Fixed per model (e.g. 32 for LLaDA2.0); one ``input_draft`` in, variable **Committed** (0..DRAFT_SIZE) + fixed **next-step** ``next_input_block`` out. |
 | **Reuse spec-decode fields** | No new core tensor types; overload meaning when plugin scheduler + worker are active. |
 | **Custom scheduler + worker + registered model** | Loaded via `--scheduler-cls` / `--worker-cls` and `vllm.general_plugins` model registration. |
 | **Commit-0** | Plugin scheduler rolls back `num_computed_tokens` when no tokens are committed in a step. |
@@ -129,7 +129,7 @@ sequenceDiagram
   DllmSched->>DllmSched: schedule read spec_token_ids
   DllmSched->>DllmSched: set scheduled_spec_decode_tokens num_scheduled_tokens equals DRAFT_SIZE
   Engine->>DllmWork: SchedulerOutput
-  DllmWork->>DllmWork: build batch from input draft
+  DllmWork->>DllmWork: build batch from input_draft
   DllmWork->>Model: forward one block plus KV context
   Model->>Remask: logits or per-position scores
   Remask->>DllmWork: committed_token_ids zero_to_DRAFT_SIZE
@@ -152,11 +152,11 @@ sequenceDiagram
 
 | vLLM field / API | Role when plugin stack is active |
 |------------------|----------------------------------|
-| `Request.spec_token_ids` | **Next-step input block** (length `DRAFT_SIZE`) for the upcoming schedule. |
-| `SchedulerOutput.scheduled_spec_decode_tokens` | **Input draft** / block (length `DRAFT_SIZE`) for this step’s forward; aligns with `RemaskingPolicy.apply(..., input_draft=...)`. |
+| `Request.spec_token_ids` | Next-step ``input_draft`` (length `DRAFT_SIZE`) for the upcoming schedule. |
+| `SchedulerOutput.scheduled_spec_decode_tokens` | This step’s ``input_draft`` (length `DRAFT_SIZE`) for the forward; aligns with `RemaskingPolicy.apply(..., input_draft=...)`. |
 | `SchedulerOutput.num_scheduled_tokens` (per request) | Set to `DRAFT_SIZE` for decode steps using the block path. |
 | `ModelRunnerOutput.sampled_token_ids` | **Committed** token IDs only, length 0..`DRAFT_SIZE` (may be empty). |
-| Worker `take_draft_token_ids()` | Returns **next-step input block** packaged as `DraftTokenIds` for engine → scheduler. |
+| Worker `take_draft_token_ids()` | Returns the next-step ``input_draft`` packaged as `DraftTokenIds` for engine → scheduler. |
 | Scheduler `update_draft_token_ids` / `update_draft_token_ids_in_output` | Store next block into `spec_token_ids`; **must not** apply AR draft grammar to dLLM blocks (override for structured output / async). |
 
 Mutually exclusive with true speculative decoding on the same requests: operators must not enable spec-decode + dLLM plugin stack together for the same run mode.
@@ -176,14 +176,14 @@ flowchart TB
   Forward --> State
   State --> Policy[RemaskingPolicy.apply]
   Policy --> Committed[Committed subset]
-  Policy --> NextInput[Next input block MASK plus decoded]
+  Policy --> NextInput[next_input_block MASK plus decoded]
   Committed --> OutSched[sampled_token_ids]
   NextInput --> OutDraft[DraftTokenIds]
 ```
 
 **MVP contract (conceptual):**
 
-- **Input:** Current **input draft** (`input_draft` on `RemaskingPolicy.apply`), logits (or equivalent), optional request config (threshold, mask id, denoise step index, etc.).
+- **Input:** ``input_draft`` (length `DRAFT_SIZE`), logits (or equivalent), optional request config (threshold, mask id, denoise step index, etc.).
 - **Output:** `committed_token_ids: list[int]` (0..N), `next_input_block: list[int]` (length `DRAFT_SIZE`), and internal mask/draft state for logging.
 
 **Shape checks:** `RemaskStepResult` (see `vllm_dllm_plugin.remasking`) does not validate lengths at construction. After `RemaskingPolicy.apply`, the worker or policy boundary should run `validate_remask_step_result()` (same package) or the concrete policy should raise `ValueError` for invalid shapes, consistent with the protocol docstring on `apply`.
@@ -192,7 +192,9 @@ flowchart TB
 
 **Protocol runtime checks:** `RemaskingPolicy` is `@runtime_checkable`; `isinstance(obj, RemaskingPolicy)` only checks for a callable `apply`, not full signature compliance or return types. Use tests and static typing for the real contract.
 
-**LLaDA2.0 default** is `vllm_dllm_plugin.remasking.llada2_default.Llada2DefaultRemaskingPolicy` (issue #7): per-position argmax and softmax probability at that token; only **mask** positions join confidence-based transfers; decoded positions are preserved; a **transfer-count schedule** over `denoise_steps` (or a `num_transfer` override) combines **inclusive** thresholding (`confidence >= commit_confidence_threshold`) with a top‑k fallback on masked positions when too few meet the threshold. While the output draft still contains `mask_token_id`, `committed_token_ids` is **empty** and progress is carried in `next_input_block`; when no mask remains, the policy returns the full decoded block as `committed_token_ids` and sets `next_input_block` to an all-mask draft for the following block. Optional `remasking_config` keys and defaults are summarized in `docs/CONTRACTS.md`. Additional policies can plug in as new `RemaskingPolicy` implementations without changing the worker’s engine contract.
+**LLaDA2.0 default** is `vllm_dllm_plugin.remasking.llada2_default.Llada2DefaultRemaskingPolicy` (issue #7): per-position argmax and softmax probability at that token; only **mask** positions join confidence-based transfers; decoded positions are preserved; a **transfer-count schedule** over `denoise_steps` (or a `num_transfer` override) combines **strict** thresholding (`confidence > commit_confidence_threshold`) with a top‑k fallback on masked positions when too few exceed the threshold. While the output draft still contains `mask_token_id`, `committed_token_ids` is **empty** and progress is carried in `next_input_block`; when no mask remains, the policy returns the full decoded block as `committed_token_ids` and sets `next_input_block` to an all-mask draft for the following block. Optional `remasking_config` keys and defaults are summarized in `docs/CONTRACTS.md`. Additional policies can plug in as new `RemaskingPolicy` implementations without changing the worker’s engine contract.
+
+**Reference (transfer mechanics):** Mask-gated confidence, per-step transfer counts from `get_num_transfer_tokens`-style layout, strict `confidence > threshold`, and top‑k fallback follow Hugging Face Diffusers [`BlockRefinementScheduler`](https://github.com/huggingface/diffusers/blob/main/src/diffusers/schedulers/scheduling_block_refinement.py) (`get_num_transfer_tokens`, `step`). [`LLaDA2Pipeline`](https://github.com/huggingface/diffusers/blob/main/src/diffusers/pipelines/llada2/pipeline_llada2.py) composes that scheduler for end-to-end block refinement. vLLM-specific **`input_draft`** / Option A semantics remain plugin-layer (§6–7 above).
 
 ---
 
@@ -267,7 +269,7 @@ vllm serve <model> \
   --worker-cls vllm_dllm_plugin.worker:DllmWorker
 ```
 
-FQCNs are placeholders until the MVP classes land. Before the first decode schedule, `request.spec_token_ids` must hold the first input block (`DRAFT_SIZE` tokens); the plugin scheduler or worker initializes it (prompt suffix + mask padding per this MVP design).
+FQCNs are placeholders until the MVP classes land. Before the first decode schedule, `request.spec_token_ids` must hold the first ``input_draft`` (`DRAFT_SIZE` tokens); the plugin scheduler or worker initializes it (prompt suffix + mask padding per this MVP design).
 
 ---
 

--- a/docs/MOCK_STACK_MODEL.md
+++ b/docs/MOCK_STACK_MODEL.md
@@ -58,6 +58,12 @@ Sizes are hints for tensor shapes; the mock does not implement a real transforme
   `[num_tokens, vocab_size]` with a **non-normalized** stub (zeros plus `1.0` at
   index `0`). Suitable for shape/device/dtype checks and degenerate argmax bias;
   not a proper probability distribution for logprob or diversity assertions.
+
+**Remasking unit tests:** `Llada2DefaultRemaskingPolicy` expects drafts that use
+the configured **mask token id** (see `LLADA2_DEFAULT_MASK_TOKEN_ID` in
+`vllm_dllm_plugin.config`) for positions still being refined — not arbitrary
+token sequences. Pair stub logits with an all-mask or mixed-mask draft when
+asserting transfer behavior.
 - **Non-last PP stage:** `compute_logits` returns `None` (vLLM convention).
 - **`forward`:** returns hidden states (or `IntermediateTensors` for PP) with
   hidden width `hidden_size`.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,3 +15,8 @@ def test_model_and_flag_constants_are_non_empty() -> None:
     assert config.LLADA2_ARCHITECTURE_NAME
     assert config.DLLM_MOCK_STACK_MODEL_ID
     assert isinstance(config.DLLM_STRICT_STACK_VALIDATION_DEFAULT, bool)
+
+
+def test_llada2_default_remasking_defaults() -> None:
+    assert isinstance(config.LLADA2_DEFAULT_MASK_TOKEN_ID, int)
+    assert isinstance(config.LLADA2_DEFAULT_COMMIT_CONFIDENCE_THRESHOLD, float)

--- a/tests/test_llada2_default.py
+++ b/tests/test_llada2_default.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for :class:`~vllm_dllm_plugin.remasking.Llada2DefaultRemaskingPolicy`."""
+
+from __future__ import annotations
+
+import pytest
+
+from vllm_dllm_plugin.config import (
+    DRAFT_SIZE,
+    LLADA2_DEFAULT_COMMIT_CONFIDENCE_THRESHOLD,
+    LLADA2_DEFAULT_MASK_TOKEN_ID,
+)
+from vllm_dllm_plugin.remasking import (
+    Llada2DefaultRemaskingPolicy,
+    RemaskingPolicy,
+    validate_remask_step_result,
+)
+
+
+def _input_block() -> tuple[int, ...]:
+    return tuple(range(DRAFT_SIZE))
+
+
+def _mock_stub_row(*, vocab_size: int = 256) -> list[float]:
+    """Match ``docs/MOCK_STACK_MODEL.md`` stub: zeros plus ``1.0`` at index ``0``."""
+    row = [0.0] * vocab_size
+    row[0] = 1.0
+    return row
+
+
+def _mock_logits(*, vocab_size: int = 256) -> list[list[float]]:
+    return [_mock_stub_row(vocab_size=vocab_size) for _ in range(DRAFT_SIZE)]
+
+
+def test_llada2_default_is_remasking_policy() -> None:
+    policy = Llada2DefaultRemaskingPolicy()
+    assert isinstance(policy, RemaskingPolicy)
+
+
+def test_mock_shaped_logits_commit_argmax_zero() -> None:
+    policy = Llada2DefaultRemaskingPolicy()
+    logits = _mock_logits(vocab_size=256)
+    out = policy.apply(input_block=_input_block(), logits=logits)
+    validate_remask_step_result(out)
+    assert out.committed_token_ids == (0,) * DRAFT_SIZE
+    assert out.next_input_block == (0,) * DRAFT_SIZE
+
+
+def test_uniform_logits_all_remask() -> None:
+    """Equal logits -> low max-softmax prob -> no commits; next block is all mask."""
+    policy = Llada2DefaultRemaskingPolicy()
+    # Need vocab large enough that 1/vocab < default threshold (0.01).
+    row = [0.0] * 128
+    logits = [list(row) for _ in range(DRAFT_SIZE)]
+    out = policy.apply(input_block=_input_block(), logits=logits)
+    validate_remask_step_result(out)
+    assert out.committed_token_ids == ()
+    assert out.next_input_block == (LLADA2_DEFAULT_MASK_TOKEN_ID,) * DRAFT_SIZE
+
+
+def test_high_confidence_commits_custom_argmax() -> None:
+    policy = Llada2DefaultRemaskingPolicy()
+    row = [0.0] * 8
+    row[3] = 50.0
+    logits = [list(row) for _ in range(DRAFT_SIZE)]
+    out = policy.apply(input_block=_input_block(), logits=logits)
+    assert out.committed_token_ids == (3,) * DRAFT_SIZE
+    assert out.next_input_block == (3,) * DRAFT_SIZE
+
+
+def test_threshold_boundary_remasks_mock_when_raised() -> None:
+    """Slightly above mock stub max-softmax (~0.0105 at vocab 256) remasks all."""
+    policy = Llada2DefaultRemaskingPolicy()
+    logits = _mock_logits(vocab_size=256)
+    out = policy.apply(
+        input_block=_input_block(),
+        logits=logits,
+        remasking_config={"commit_confidence_threshold": 0.011},
+    )
+    assert out.committed_token_ids == ()
+    assert out.next_input_block == (LLADA2_DEFAULT_MASK_TOKEN_ID,) * DRAFT_SIZE
+
+
+def test_custom_mask_token_id() -> None:
+    policy = Llada2DefaultRemaskingPolicy()
+    row = [0.0] * 8
+    logits = [list(row) for _ in range(DRAFT_SIZE)]
+    # Uniform row: max softmax prob is 1/8 = 0.125; require > 0.2 to remask all.
+    out = policy.apply(
+        input_block=_input_block(),
+        logits=logits,
+        remasking_config={"mask_token_id": 99, "commit_confidence_threshold": 0.2},
+    )
+    assert out.next_input_block == (99,) * DRAFT_SIZE
+
+
+def test_logits_none_raises() -> None:
+    policy = Llada2DefaultRemaskingPolicy()
+    with pytest.raises(ValueError, match="logits is required"):
+        policy.apply(input_block=_input_block(), logits=None)
+
+
+def test_wrong_input_block_length_raises() -> None:
+    policy = Llada2DefaultRemaskingPolicy()
+    with pytest.raises(ValueError, match="input_block"):
+        policy.apply(input_block=(1, 2, 3), logits=_mock_logits())
+
+
+def test_wrong_logits_first_dim_raises() -> None:
+    policy = Llada2DefaultRemaskingPolicy()
+    short = [_mock_stub_row() for _ in range(3)]
+    with pytest.raises(ValueError, match="first dimension"):
+        policy.apply(input_block=_input_block(), logits=short)
+
+
+def test_inconsistent_vocab_width_raises() -> None:
+    policy = Llada2DefaultRemaskingPolicy()
+    bad_logits = [[0.0, 1.0]] + [[0.0] * 8 for _ in range(DRAFT_SIZE - 1)]
+    with pytest.raises(ValueError, match="inconsistent vocab"):
+        policy.apply(input_block=_input_block(), logits=bad_logits)
+
+
+def test_default_threshold_constant_documented() -> None:
+    assert 0.0 < LLADA2_DEFAULT_COMMIT_CONFIDENCE_THRESHOLD < 1.0
+
+
+def test_torch_tensor_logits_matches_nested_list() -> None:
+    torch = pytest.importorskip("torch")
+    policy = Llada2DefaultRemaskingPolicy()
+    rows = _mock_logits(vocab_size=16)
+    list_out = policy.apply(input_block=_input_block(), logits=rows)
+    tensor = torch.tensor(rows, dtype=torch.float32)
+    tensor_out = policy.apply(input_block=_input_block(), logits=tensor)
+    assert list_out == tensor_out

--- a/tests/test_llada2_default.py
+++ b/tests/test_llada2_default.py
@@ -18,8 +18,8 @@ from vllm_dllm_plugin.remasking import (
 )
 
 
-def _input_block() -> tuple[int, ...]:
-    return tuple(range(DRAFT_SIZE))
+def _draft_all_mask() -> tuple[int, ...]:
+    return (LLADA2_DEFAULT_MASK_TOKEN_ID,) * DRAFT_SIZE
 
 
 def _mock_stub_row(*, vocab_size: int = 256) -> list[float]:
@@ -38,97 +38,216 @@ def test_llada2_default_is_remasking_policy() -> None:
     assert isinstance(policy, RemaskingPolicy)
 
 
-def test_mock_shaped_logits_commit_argmax_zero() -> None:
+def test_mock_shaped_logits_all_mask_terminal() -> None:
+    """Stub logits: all masks high-confidence; one step clears the block."""
     policy = Llada2DefaultRemaskingPolicy()
     logits = _mock_logits(vocab_size=256)
-    out = policy.apply(input_block=_input_block(), logits=logits)
+    out = policy.apply(input_draft=_draft_all_mask(), logits=logits)
     validate_remask_step_result(out)
     assert out.committed_token_ids == (0,) * DRAFT_SIZE
-    assert out.next_input_block == (0,) * DRAFT_SIZE
-
-
-def test_uniform_logits_all_remask() -> None:
-    """Equal logits -> low max-softmax prob -> no commits; next block is all mask."""
-    policy = Llada2DefaultRemaskingPolicy()
-    # Need vocab large enough that 1/vocab < default threshold (0.01).
-    row = [0.0] * 128
-    logits = [list(row) for _ in range(DRAFT_SIZE)]
-    out = policy.apply(input_block=_input_block(), logits=logits)
-    validate_remask_step_result(out)
-    assert out.committed_token_ids == ()
     assert out.next_input_block == (LLADA2_DEFAULT_MASK_TOKEN_ID,) * DRAFT_SIZE
 
 
-def test_logit_tie_breaks_to_smallest_index() -> None:
-    """Equal top logits: pick smallest index (aligns with typical argmax)."""
+def test_uniform_logits_topk_one_transfer_option_a() -> None:
+    """Equal logits below threshold: top-k picks one masked index (smallest)."""
+    policy = Llada2DefaultRemaskingPolicy()
+    row = [0.0] * 128
+    logits = [list(row) for _ in range(DRAFT_SIZE)]
+    out = policy.apply(input_draft=_draft_all_mask(), logits=logits)
+    validate_remask_step_result(out)
+    assert out.committed_token_ids == ()
+    expected = [LLADA2_DEFAULT_MASK_TOKEN_ID] * DRAFT_SIZE
+    expected[0] = 0
+    assert out.next_input_block == tuple(expected)
+
+
+def test_logit_tie_breaks_to_smallest_index_topk() -> None:
+    """Tied max logits: argmax at 0; top-k uses smallest index among ties."""
     policy = Llada2DefaultRemaskingPolicy()
     row = [1.0, 1.0, 0.0, 0.0]
     logits = [list(row) for _ in range(DRAFT_SIZE)]
-    out = policy.apply(input_block=_input_block(), logits=logits)
-    assert out.committed_token_ids == (0,) * DRAFT_SIZE
-    assert out.next_input_block == (0,) * DRAFT_SIZE
+    out = policy.apply(
+        input_draft=_draft_all_mask(),
+        logits=logits,
+        remasking_config={"commit_confidence_threshold": 0.99},
+    )
+    assert out.committed_token_ids == ()
+    expected = [LLADA2_DEFAULT_MASK_TOKEN_ID] * DRAFT_SIZE
+    expected[0] = 0
+    assert out.next_input_block == tuple(expected)
 
 
-def test_high_confidence_commits_custom_argmax() -> None:
+def test_preserve_decoded_positions_only_masked_transfer() -> None:
+    """Literal tokens stay fixed; only mask slots use logits-driven transfers."""
+    policy = Llada2DefaultRemaskingPolicy()
+    prefix = (42,) * (DRAFT_SIZE // 2)
+    suffix_masks = (LLADA2_DEFAULT_MASK_TOKEN_ID,) * (DRAFT_SIZE // 2)
+    draft = prefix + suffix_masks
+    row_low = [0.0] * 128
+    row_high = [0.0] * 128
+    row_high[3] = 50.0
+    logits: list[list[float]] = []
+    for i in range(DRAFT_SIZE):
+        if i < DRAFT_SIZE // 2:
+            logits.append(list(row_low))
+        elif i < DRAFT_SIZE // 2 + DRAFT_SIZE // 4:
+            logits.append(list(row_high))
+        else:
+            logits.append(list(row_low))
+    out = policy.apply(
+        input_draft=draft,
+        logits=logits,
+        remasking_config={"commit_confidence_threshold": 0.15},
+    )
+    assert out.committed_token_ids == ()
+    next_list = list(out.next_input_block)
+    assert next_list[: DRAFT_SIZE // 2] == list(prefix)
+    for i in range(DRAFT_SIZE // 2, DRAFT_SIZE // 2 + DRAFT_SIZE // 4):
+        assert next_list[i] == 3
+    for i in range(DRAFT_SIZE // 2 + DRAFT_SIZE // 4, DRAFT_SIZE):
+        assert next_list[i] == LLADA2_DEFAULT_MASK_TOKEN_ID
+
+
+def test_terminal_input_already_unmasked() -> None:
+    """No mask in input: full block commit and all-mask next draft."""
+    policy = Llada2DefaultRemaskingPolicy()
+    # Avoid token id ``LLADA2_DEFAULT_MASK_TOKEN_ID`` in the draft (e.g. ``1``).
+    draft = tuple(i * 2 for i in range(DRAFT_SIZE))
+    logits = _mock_logits(vocab_size=16)
+    out = policy.apply(input_draft=draft, logits=logits)
+    validate_remask_step_result(out)
+    assert out.committed_token_ids == draft
+    assert out.next_input_block == (LLADA2_DEFAULT_MASK_TOKEN_ID,) * DRAFT_SIZE
+
+
+def test_high_confidence_flood_transfers_all_above_threshold() -> None:
+    """When h >= num_to_transfer, every high-confidence masked position transfers."""
+    policy = Llada2DefaultRemaskingPolicy()
+    high = [0.0] * 128
+    high[7] = 50.0
+    low = [0.0] * 128
+    logits = [list(high) for _ in range(5)] + [list(low) for _ in range(DRAFT_SIZE - 5)]
+    out = policy.apply(
+        input_draft=_draft_all_mask(),
+        logits=logits,
+        remasking_config={
+            "commit_confidence_threshold": 0.15,
+            "num_transfer": 2,
+        },
+    )
+    assert out.committed_token_ids == ()
+    for i in range(5):
+        assert out.next_input_block[i] == 7
+    for i in range(5, DRAFT_SIZE):
+        assert out.next_input_block[i] == LLADA2_DEFAULT_MASK_TOKEN_ID
+
+
+def test_topk_branch_all_strictly_below_threshold() -> None:
+    """No position meets threshold; top-k moves min(num_transfer, num_masked) slots."""
+    policy = Llada2DefaultRemaskingPolicy()
+    row = [0.0] * 128
+    logits = [list(row) for _ in range(DRAFT_SIZE)]
+    out = policy.apply(
+        input_draft=_draft_all_mask(),
+        logits=logits,
+        remasking_config={
+            "commit_confidence_threshold": 1.0,
+            "num_transfer": 3,
+        },
+    )
+    assert out.committed_token_ids == ()
+    expected = [LLADA2_DEFAULT_MASK_TOKEN_ID] * DRAFT_SIZE
+    for i in range(3):
+        expected[i] = 0
+    assert out.next_input_block == tuple(expected)
+
+
+def test_threshold_inclusive_equals_counts_as_high_confidence() -> None:
+    """``confidence == threshold`` counts as high-confidence (inclusive bound)."""
     policy = Llada2DefaultRemaskingPolicy()
     row = [0.0] * 8
-    row[3] = 50.0
     logits = [list(row) for _ in range(DRAFT_SIZE)]
-    out = policy.apply(input_block=_input_block(), logits=logits)
-    assert out.committed_token_ids == (3,) * DRAFT_SIZE
-    assert out.next_input_block == (3,) * DRAFT_SIZE
+    out = policy.apply(
+        input_draft=_draft_all_mask(),
+        logits=logits,
+        remasking_config={"commit_confidence_threshold": 0.125},
+    )
+    assert out.committed_token_ids == (0,) * DRAFT_SIZE
+    assert out.next_input_block == (LLADA2_DEFAULT_MASK_TOKEN_ID,) * DRAFT_SIZE
 
 
-def test_threshold_boundary_remasks_mock_when_raised() -> None:
-    """Slightly above mock stub max-softmax (~0.0105 at vocab 256) remasks all."""
+def test_option_a_mid_step_empty_committed() -> None:
+    """Draft still has mask: ``committed_token_ids`` stays empty (Option A)."""
+    policy = Llada2DefaultRemaskingPolicy()
+    row = [0.0] * 128
+    logits = [list(row) for _ in range(DRAFT_SIZE)]
+    out = policy.apply(input_draft=_draft_all_mask(), logits=logits)
+    assert out.committed_token_ids == ()
+    assert LLADA2_DEFAULT_MASK_TOKEN_ID in out.next_input_block
+
+
+def test_threshold_above_mock_softmax_no_terminal() -> None:
+    """Threshold above stub softmax mass -> top-k path; still mid-block (Option A)."""
     policy = Llada2DefaultRemaskingPolicy()
     logits = _mock_logits(vocab_size=256)
     out = policy.apply(
-        input_block=_input_block(),
+        input_draft=_draft_all_mask(),
         logits=logits,
         remasking_config={"commit_confidence_threshold": 0.011},
     )
     assert out.committed_token_ids == ()
-    assert out.next_input_block == (LLADA2_DEFAULT_MASK_TOKEN_ID,) * DRAFT_SIZE
+    assert out.next_input_block[0] == 0
+    assert LLADA2_DEFAULT_MASK_TOKEN_ID in out.next_input_block
 
 
 def test_custom_mask_token_id() -> None:
     policy = Llada2DefaultRemaskingPolicy()
     row = [0.0] * 8
     logits = [list(row) for _ in range(DRAFT_SIZE)]
-    # Uniform row: max softmax prob is 1/8 = 0.125; require > 0.2 to remask all.
     out = policy.apply(
-        input_block=_input_block(),
+        input_draft=(99,) * DRAFT_SIZE,
         logits=logits,
-        remasking_config={"mask_token_id": 99, "commit_confidence_threshold": 0.2},
+        remasking_config={"mask_token_id": 99, "commit_confidence_threshold": 0.5},
     )
-    assert out.next_input_block == (99,) * DRAFT_SIZE
+    assert out.committed_token_ids == ()
+    assert out.next_input_block[0] == 0
+    assert 99 in out.next_input_block
 
 
 def test_logits_none_raises() -> None:
     policy = Llada2DefaultRemaskingPolicy()
     with pytest.raises(ValueError, match="logits is required"):
-        policy.apply(input_block=_input_block(), logits=None)
+        policy.apply(input_draft=_draft_all_mask(), logits=None)
 
 
-def test_wrong_input_block_length_raises() -> None:
+def test_wrong_input_draft_length_raises() -> None:
     policy = Llada2DefaultRemaskingPolicy()
-    with pytest.raises(ValueError, match="input_block"):
-        policy.apply(input_block=(1, 2, 3), logits=_mock_logits())
+    with pytest.raises(ValueError, match="input_draft"):
+        policy.apply(input_draft=(1, 2, 3), logits=_mock_logits())
 
 
 def test_wrong_logits_first_dim_raises() -> None:
     policy = Llada2DefaultRemaskingPolicy()
     short = [_mock_stub_row() for _ in range(3)]
     with pytest.raises(ValueError, match="first dimension"):
-        policy.apply(input_block=_input_block(), logits=short)
+        policy.apply(input_draft=_draft_all_mask(), logits=short)
 
 
 def test_inconsistent_vocab_width_raises() -> None:
     policy = Llada2DefaultRemaskingPolicy()
     bad_logits = [[0.0, 1.0]] + [[0.0] * 8 for _ in range(DRAFT_SIZE - 1)]
     with pytest.raises(ValueError, match="inconsistent vocab"):
-        policy.apply(input_block=_input_block(), logits=bad_logits)
+        policy.apply(input_draft=_draft_all_mask(), logits=bad_logits)
+
+
+def test_denoise_steps_zero_raises() -> None:
+    policy = Llada2DefaultRemaskingPolicy()
+    with pytest.raises(ValueError, match="denoise_steps must be positive"):
+        policy.apply(
+            input_draft=_draft_all_mask(),
+            logits=_mock_logits(),
+            remasking_config={"denoise_steps": 0},
+        )
 
 
 def test_default_threshold_constant_documented() -> None:
@@ -139,7 +258,7 @@ def test_torch_tensor_logits_matches_nested_list() -> None:
     torch = pytest.importorskip("torch")
     policy = Llada2DefaultRemaskingPolicy()
     rows = _mock_logits(vocab_size=16)
-    list_out = policy.apply(input_block=_input_block(), logits=rows)
+    list_out = policy.apply(input_draft=_draft_all_mask(), logits=rows)
     tensor = torch.tensor(rows, dtype=torch.float32)
-    tensor_out = policy.apply(input_block=_input_block(), logits=tensor)
+    tensor_out = policy.apply(input_draft=_draft_all_mask(), logits=tensor)
     assert list_out == tensor_out

--- a/tests/test_llada2_default.py
+++ b/tests/test_llada2_default.py
@@ -59,6 +59,16 @@ def test_uniform_logits_all_remask() -> None:
     assert out.next_input_block == (LLADA2_DEFAULT_MASK_TOKEN_ID,) * DRAFT_SIZE
 
 
+def test_logit_tie_breaks_to_smallest_index() -> None:
+    """Equal top logits: pick smallest index (aligns with typical argmax)."""
+    policy = Llada2DefaultRemaskingPolicy()
+    row = [1.0, 1.0, 0.0, 0.0]
+    logits = [list(row) for _ in range(DRAFT_SIZE)]
+    out = policy.apply(input_block=_input_block(), logits=logits)
+    assert out.committed_token_ids == (0,) * DRAFT_SIZE
+    assert out.next_input_block == (0,) * DRAFT_SIZE
+
+
 def test_high_confidence_commits_custom_argmax() -> None:
     policy = Llada2DefaultRemaskingPolicy()
     row = [0.0] * 8

--- a/tests/test_llada2_default.py
+++ b/tests/test_llada2_default.py
@@ -162,8 +162,8 @@ def test_topk_branch_all_strictly_below_threshold() -> None:
     assert out.next_input_block == tuple(expected)
 
 
-def test_threshold_inclusive_equals_counts_as_high_confidence() -> None:
-    """``confidence == threshold`` counts as high-confidence (inclusive bound)."""
+def test_threshold_strict_excludes_equality() -> None:
+    """HF/Diffusers: ``confidence > threshold``; equality uses top-k, not high-conf."""
     policy = Llada2DefaultRemaskingPolicy()
     row = [0.0] * 8
     logits = [list(row) for _ in range(DRAFT_SIZE)]
@@ -172,8 +172,10 @@ def test_threshold_inclusive_equals_counts_as_high_confidence() -> None:
         logits=logits,
         remasking_config={"commit_confidence_threshold": 0.125},
     )
-    assert out.committed_token_ids == (0,) * DRAFT_SIZE
-    assert out.next_input_block == (LLADA2_DEFAULT_MASK_TOKEN_ID,) * DRAFT_SIZE
+    assert out.committed_token_ids == ()
+    expected = [LLADA2_DEFAULT_MASK_TOKEN_ID] * DRAFT_SIZE
+    expected[0] = 0
+    assert out.next_input_block == tuple(expected)
 
 
 def test_option_a_mid_step_empty_committed() -> None:

--- a/tests/test_remasking_base.py
+++ b/tests/test_remasking_base.py
@@ -23,11 +23,11 @@ class _StubPolicy:
     def apply(
         self,
         *,
-        input_block: list[int] | tuple[int, ...],
+        input_draft: list[int] | tuple[int, ...],
         logits: Any | None = None,
         remasking_config: Mapping[str, Any] | None = None,
     ) -> RemaskStepResult:
-        del input_block, logits, remasking_config
+        del input_draft, logits, remasking_config
         return RemaskStepResult(
             committed_token_ids=(),
             next_input_block=(0,) * DRAFT_SIZE,
@@ -37,7 +37,7 @@ class _StubPolicy:
 def test_remasking_policy_structural_subtype() -> None:
     stub = _StubPolicy()
     assert isinstance(stub, RemaskingPolicy)
-    out = stub.apply(input_block=tuple(range(DRAFT_SIZE)))
+    out = stub.apply(input_draft=tuple(range(DRAFT_SIZE)))
     validate_remask_step_result(out)
 
 

--- a/vllm_dllm_plugin/config.py
+++ b/vllm_dllm_plugin/config.py
@@ -34,3 +34,13 @@ DLLM_MOCK_MODEL_CLASS_FQCN: Final[str] = (
 #: scheduler / worker / model combinations as errors once that module exists.
 #: Operators or tests may override via future config wiring; this is the default.
 DLLM_STRICT_STACK_VALIDATION_DEFAULT: Final[bool] = True
+
+#: Placeholder **mask** token id for :mod:`~vllm_dllm_plugin.remasking.llada2_default`
+#: ``next_input_block`` remasked positions until real HF config lands (Phase 7 / #12).
+LLADA2_DEFAULT_MASK_TOKEN_ID: Final[int] = 1
+
+#: Default minimum softmax probability on the per-position argmax token required to
+#: **commit** that position (issue #7). Tuned so the Phase 2 mock stub logits
+#: (zeros + ``1.0`` at index ``0``, ``docs/MOCK_STACK_MODEL.md``) commit under
+#: default settings for stack tests.
+LLADA2_DEFAULT_COMMIT_CONFIDENCE_THRESHOLD: Final[float] = 0.01

--- a/vllm_dllm_plugin/config.py
+++ b/vllm_dllm_plugin/config.py
@@ -14,9 +14,9 @@ from typing import Final
 #: LLaDA2.0 MVP uses 32 per ``docs/DESIGN_MVP.md`` (Goals table, section 1).
 DRAFT_SIZE: Final[int] = 32
 
-#: Primary registered architecture key for the real LLaDA2.0 vLLM model module.
-#: Until Phase 7 (#12), registration points at the **mock** class
-#: (see ``docs/MOCK_STACK_MODEL.md``); configs using this name get stub logits.
+#: Primary registered architecture key for the real LLaDA2.0 vLLM model module
+#: (HF mapping). Until Phase 7 (#12), registration points at the **mock** class
+#: (see ``docs/MOCK_STACK_MODEL.md``); HF configs using this name get stub logits.
 #: Prefer ``DLLM_MOCK_STACK_MODEL_ID`` when you want an explicit test-only id.
 #: Exact registry string may be refined when ``register()`` lands (issue #5).
 LLADA2_ARCHITECTURE_NAME: Final[str] = "LLaDA2ForCausalLM"
@@ -36,7 +36,7 @@ DLLM_MOCK_MODEL_CLASS_FQCN: Final[str] = (
 DLLM_STRICT_STACK_VALIDATION_DEFAULT: Final[bool] = True
 
 #: Placeholder **mask** token id for :mod:`~vllm_dllm_plugin.remasking.llada2_default`
-#: remasked positions in drafts until model config wiring lands (Phase 7 / #12).
+#: ``next_input_block`` remasked positions until real HF config lands (Phase 7 / #12).
 LLADA2_DEFAULT_MASK_TOKEN_ID: Final[int] = 1
 
 #: Default number of denoise steps used to build the per-step **transfer count**

--- a/vllm_dllm_plugin/config.py
+++ b/vllm_dllm_plugin/config.py
@@ -14,9 +14,9 @@ from typing import Final
 #: LLaDA2.0 MVP uses 32 per ``docs/DESIGN_MVP.md`` (Goals table, section 1).
 DRAFT_SIZE: Final[int] = 32
 
-#: Primary registered architecture key for the real LLaDA2.0 vLLM model module
-#: (HF mapping). Until Phase 7 (#12), registration points at the **mock** class
-#: (see ``docs/MOCK_STACK_MODEL.md``); HF configs using this name get stub logits.
+#: Primary registered architecture key for the real LLaDA2.0 vLLM model module.
+#: Until Phase 7 (#12), registration points at the **mock** class
+#: (see ``docs/MOCK_STACK_MODEL.md``); configs using this name get stub logits.
 #: Prefer ``DLLM_MOCK_STACK_MODEL_ID`` when you want an explicit test-only id.
 #: Exact registry string may be refined when ``register()`` lands (issue #5).
 LLADA2_ARCHITECTURE_NAME: Final[str] = "LLaDA2ForCausalLM"
@@ -36,8 +36,13 @@ DLLM_MOCK_MODEL_CLASS_FQCN: Final[str] = (
 DLLM_STRICT_STACK_VALIDATION_DEFAULT: Final[bool] = True
 
 #: Placeholder **mask** token id for :mod:`~vllm_dllm_plugin.remasking.llada2_default`
-#: ``next_input_block`` remasked positions until real HF config lands (Phase 7 / #12).
+#: remasked positions in drafts until model config wiring lands (Phase 7 / #12).
 LLADA2_DEFAULT_MASK_TOKEN_ID: Final[int] = 1
+
+#: Default number of denoise steps used to build the per-step **transfer count**
+#: schedule (``block_len // steps`` layout). Matches ``DRAFT_SIZE`` for one transfer
+#: per step when the schedule is not overridden.
+LLADA2_DEFAULT_DENOISE_STEPS: Final[int] = DRAFT_SIZE
 
 #: Default minimum softmax probability on the per-position argmax token required to
 #: **commit** that position (issue #7). Tuned so the Phase 2 mock stub logits

--- a/vllm_dllm_plugin/remasking/__init__.py
+++ b/vllm_dllm_plugin/remasking/__init__.py
@@ -9,8 +9,10 @@ from vllm_dllm_plugin.remasking.base import (
     RemaskStepResult,
     validate_remask_step_result,
 )
+from vllm_dllm_plugin.remasking.llada2_default import Llada2DefaultRemaskingPolicy
 
 __all__ = [
+    "Llada2DefaultRemaskingPolicy",
     "RemaskStepResult",
     "RemaskingPolicy",
     "validate_remask_step_result",

--- a/vllm_dllm_plugin/remasking/base.py
+++ b/vllm_dllm_plugin/remasking/base.py
@@ -4,7 +4,7 @@
 
 Invariants align with ``docs/DESIGN_MVP.md`` section 8 (remasking composability)
 and use :data:`~vllm_dllm_plugin.config.DRAFT_SIZE` for next-block length.
-Concrete policies (e.g. LLaDA2.0 default) live in separate modules (issue #7).
+Concrete policies live in separate modules (e.g. ``llada2_default`` for LLaDA2.0).
 """
 
 from __future__ import annotations

--- a/vllm_dllm_plugin/remasking/base.py
+++ b/vllm_dllm_plugin/remasking/base.py
@@ -46,7 +46,7 @@ class RemaskingPolicy(Protocol):
 
     **MVP contract (conceptual, section 8):**
 
-    - **Input:** current input block, logits or equivalent scores, optional
+    - **Input:** current input draft, logits or equivalent scores, optional
       policy knobs (threshold, top-k, etc.).
     - **Output:** committed ids (subset of positions), next input block of length
       ``DRAFT_SIZE``, and (in concrete implementations) internal mask/draft
@@ -65,14 +65,14 @@ class RemaskingPolicy(Protocol):
     def apply(
         self,
         *,
-        input_block: Sequence[int],
+        input_draft: Sequence[int],
         logits: Any | None = None,
         remasking_config: Mapping[str, Any] | None = None,
     ) -> RemaskStepResult:
         """Run one remasking step for the current block.
 
         Args:
-            input_block: This step's **input block** (length typically
+            input_draft: This step's **input draft** (length typically
                 ``DRAFT_SIZE`` for decode), aligned with
                 ``SchedulerOutput.scheduled_spec_decode_tokens``
                 (``DESIGN_MVP`` section 7).

--- a/vllm_dllm_plugin/remasking/llada2_default.py
+++ b/vllm_dllm_plugin/remasking/llada2_default.py
@@ -5,8 +5,9 @@
 Per-position **argmax** token and **softmax probability** at that token (stable
 softmax). Only **mask** positions participate in confidence-based transfer; decoded
 positions are preserved. Each step uses a **transfer count** from a schedule over
-``denoise_steps`` (or a ``num_transfer`` override). If enough masked positions meet
-``commit_confidence_threshold`` (**inclusive** ``>=``), all of them transfer; otherwise
+``denoise_steps`` (or a ``num_transfer`` override). If enough masked positions have
+softmax probability at the argmax **strictly greater than**
+``commit_confidence_threshold``, all of them transfer; otherwise
 the top-``k`` masked positions by confidence transfer (``k`` capped by mask count),
 with **smallest index** winning ties.
 
@@ -17,8 +18,9 @@ step returns the full decoded block as ``committed_token_ids`` and sets
 
 **``remasking_config`` keys** (optional; stable for issue #13 / worker wiring):
 
-- ``commit_confidence_threshold`` (``float``): minimum softmax probability on the
-  argmax token for a masked position to count as high-confidence (default
+- ``commit_confidence_threshold`` (``float``): masked positions count as
+  high-confidence when softmax probability at the argmax token is **strictly**
+  greater than this value (default
   :data:`~vllm_dllm_plugin.config.LLADA2_DEFAULT_COMMIT_CONFIDENCE_THRESHOLD`).
 - ``mask_token_id`` (``int``): mask placeholder in drafts (default
   :data:`~vllm_dllm_plugin.config.LLADA2_DEFAULT_MASK_TOKEN_ID`).
@@ -190,7 +192,7 @@ class Llada2DefaultRemaskingPolicy:
         neg_inf = float("-inf")
         confidence = [probs[i] if masked[i] else neg_inf for i in range(DRAFT_SIZE)]
         high_conf = [
-            masked[i] and (confidence[i] >= threshold) for i in range(DRAFT_SIZE)
+            masked[i] and (confidence[i] > threshold) for i in range(DRAFT_SIZE)
         ]
         h = sum(high_conf)
 

--- a/vllm_dllm_plugin/remasking/llada2_default.py
+++ b/vllm_dllm_plugin/remasking/llada2_default.py
@@ -2,25 +2,35 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """MVP default remasking policy for LLaDA2.0 (milestone issue #7).
 
-Uses per-position **argmax** token and **softmax confidence** (probability mass on
-that token) after a **numerically stable** softmax. Positions with confidence
-below a threshold are **remasked** in ``next_input_block`` using ``mask_token_id``.
+Per-position **argmax** token and **softmax probability** at that token (stable
+softmax). Only **mask** positions participate in confidence-based transfer; decoded
+positions are preserved. Each step uses a **transfer count** from a schedule over
+``denoise_steps`` (or a ``num_transfer`` override). If enough masked positions meet
+``commit_confidence_threshold`` (**inclusive** ``>=``), all of them transfer; otherwise
+the top-``k`` masked positions by confidence transfer (``k`` capped by mask count),
+with **smallest index** winning ties.
+
+While the output draft still contains ``mask_token_id``, ``committed_token_ids`` is
+empty and progress is carried in ``next_input_block``. When no mask remains, this
+step returns the full decoded block as ``committed_token_ids`` and sets
+``next_input_block`` to an all-mask draft for the following block handoff.
 
 **``remasking_config`` keys** (optional; stable for issue #13 / worker wiring):
 
 - ``commit_confidence_threshold`` (``float``): minimum softmax probability on the
-  argmax token to commit (default
+  argmax token for a masked position to count as high-confidence (default
   :data:`~vllm_dllm_plugin.config.LLADA2_DEFAULT_COMMIT_CONFIDENCE_THRESHOLD`).
-- ``mask_token_id`` (``int``): filler for remasked positions in ``next_input_block``
-  (default :data:`~vllm_dllm_plugin.config.LLADA2_DEFAULT_MASK_TOKEN_ID`).
+- ``mask_token_id`` (``int``): mask placeholder in drafts (default
+  :data:`~vllm_dllm_plugin.config.LLADA2_DEFAULT_MASK_TOKEN_ID`).
+- ``denoise_steps`` (``int``): schedule length; default
+  :data:`~vllm_dllm_plugin.config.LLADA2_DEFAULT_DENOISE_STEPS`.
+- ``denoise_step_index`` (``int``): zero-based index into the schedule; default ``0``.
+  Production callers should pass the real step.
+- ``num_transfer`` (``int``): if set, use this count instead of the schedule entry.
 
 **Logits:** 2-D, shape ``(DRAFT_SIZE, vocab_size)``. Accepts nested sequences or
 indexable row-major objects (e.g. ``torch.Tensor``) without importing ``torch``
-in this module. Callers must not pass ``logits is None`` (non-last PP ranks return
-``None`` from the mock — the worker must not invoke the policy in that case).
-
-**``committed_token_ids``:** argmax token id for each **committed** position, in
-**increasing position order** (index ``0 .. DRAFT_SIZE-1``).
+in this module. Callers must not pass ``logits is None`` when logits are required.
 """
 
 from __future__ import annotations
@@ -32,6 +42,7 @@ from typing import Any
 from vllm_dllm_plugin.config import (
     DRAFT_SIZE,
     LLADA2_DEFAULT_COMMIT_CONFIDENCE_THRESHOLD,
+    LLADA2_DEFAULT_DENOISE_STEPS,
     LLADA2_DEFAULT_MASK_TOKEN_ID,
 )
 from vllm_dllm_plugin.remasking.base import (
@@ -99,20 +110,46 @@ def _argmax_and_max_softmax_prob(logits_row: Sequence[float]) -> tuple[int, floa
     return best, probs[best]
 
 
+def _num_transfer_schedule(block_len: int, steps: int) -> tuple[int, ...]:
+    if steps <= 0:
+        msg = "denoise_steps must be positive"
+        raise ValueError(msg)
+    base = block_len // steps
+    remainder = block_len % steps
+    out = [base] * steps
+    for i in range(remainder):
+        out[i] += 1
+    return tuple(out)
+
+
+def _topk_masked_indices(
+    *,
+    masked: list[bool],
+    confidence: list[float],
+    k: int,
+) -> list[int]:
+    """Return ``k`` masked indices with highest confidence; ties -> smaller index."""
+    if k <= 0:
+        return []
+    candidates = [i for i in range(DRAFT_SIZE) if masked[i]]
+    candidates.sort(key=lambda i: (-confidence[i], i))
+    return candidates[:k]
+
+
 class Llada2DefaultRemaskingPolicy:
     """LLaDA2.0 MVP default :class:`~vllm_dllm_plugin.remasking.RemaskingPolicy`."""
 
     def apply(
         self,
         *,
-        input_block: Sequence[int],
+        input_draft: Sequence[int],
         logits: Any | None = None,
         remasking_config: Mapping[str, Any] | None = None,
     ) -> RemaskStepResult:
-        if len(input_block) != DRAFT_SIZE:
+        if len(input_draft) != DRAFT_SIZE:
             msg = (
-                f"input_block length must be DRAFT_SIZE={DRAFT_SIZE}, "
-                f"got {len(input_block)}"
+                f"input_draft length must be DRAFT_SIZE={DRAFT_SIZE}, "
+                f"got {len(input_draft)}"
             )
             raise ValueError(msg)
         if logits is None:
@@ -128,21 +165,70 @@ class Llada2DefaultRemaskingPolicy:
             ),
         )
         mask_token_id = int(cfg.get("mask_token_id", LLADA2_DEFAULT_MASK_TOKEN_ID))
+        denoise_steps = int(cfg.get("denoise_steps", LLADA2_DEFAULT_DENOISE_STEPS))
+        denoise_step_index = int(cfg.get("denoise_step_index", 0))
 
         rows = _logits_to_rows(logits)
-        committed: list[int] = []
-        next_tokens: list[int] = []
-        for row in rows:
-            token_id, conf = _argmax_and_max_softmax_prob(row)
-            if conf >= threshold:
-                committed.append(token_id)
-                next_tokens.append(token_id)
-            else:
-                next_tokens.append(mask_token_id)
+        masked = [input_draft[i] == mask_token_id for i in range(DRAFT_SIZE)]
 
-        result = RemaskStepResult(
-            committed_token_ids=tuple(committed),
-            next_input_block=tuple(next_tokens),
-        )
+        if not any(masked):
+            next_tokens = list(input_draft)
+            result = RemaskStepResult(
+                committed_token_ids=tuple(next_tokens),
+                next_input_block=(mask_token_id,) * DRAFT_SIZE,
+            )
+            validate_remask_step_result(result)
+            return result
+
+        token_ids: list[int] = []
+        probs: list[float] = []
+        for row in rows:
+            tid, p = _argmax_and_max_softmax_prob(row)
+            token_ids.append(tid)
+            probs.append(p)
+
+        neg_inf = float("-inf")
+        confidence = [probs[i] if masked[i] else neg_inf for i in range(DRAFT_SIZE)]
+        high_conf = [
+            masked[i] and (confidence[i] >= threshold) for i in range(DRAFT_SIZE)
+        ]
+        h = sum(high_conf)
+
+        if "num_transfer" in cfg:
+            num_to_transfer = int(cfg["num_transfer"])
+            if num_to_transfer < 0:
+                msg = "num_transfer must be non-negative"
+                raise ValueError(msg)
+        else:
+            schedule = _num_transfer_schedule(DRAFT_SIZE, denoise_steps)
+            step = max(0, min(denoise_step_index, len(schedule) - 1))
+            num_to_transfer = schedule[step]
+
+        num_masked = sum(masked)
+        transfer_idx: list[int]
+        if h >= num_to_transfer:
+            transfer_idx = [i for i in range(DRAFT_SIZE) if high_conf[i]]
+        else:
+            k = min(num_to_transfer, num_masked)
+            transfer_idx = _topk_masked_indices(
+                masked=masked,
+                confidence=confidence,
+                k=k,
+            )
+
+        next_tokens = list(input_draft)
+        for i in transfer_idx:
+            next_tokens[i] = token_ids[i]
+
+        if mask_token_id not in next_tokens:
+            result = RemaskStepResult(
+                committed_token_ids=tuple(next_tokens),
+                next_input_block=(mask_token_id,) * DRAFT_SIZE,
+            )
+        else:
+            result = RemaskStepResult(
+                committed_token_ids=(),
+                next_input_block=tuple(next_tokens),
+            )
         validate_remask_step_result(result)
         return result

--- a/vllm_dllm_plugin/remasking/llada2_default.py
+++ b/vllm_dllm_plugin/remasking/llada2_default.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""MVP default remasking policy for LLaDA2.0 (milestone issue #7).
+
+Uses per-position **argmax** token and **softmax confidence** (probability mass on
+that token) after a **numerically stable** softmax. Positions with confidence
+below a threshold are **remasked** in ``next_input_block`` using ``mask_token_id``.
+
+**``remasking_config`` keys** (optional; stable for issue #13 / worker wiring):
+
+- ``commit_confidence_threshold`` (``float``): minimum softmax probability on the
+  argmax token to commit (default
+  :data:`~vllm_dllm_plugin.config.LLADA2_DEFAULT_COMMIT_CONFIDENCE_THRESHOLD`).
+- ``mask_token_id`` (``int``): filler for remasked positions in ``next_input_block``
+  (default :data:`~vllm_dllm_plugin.config.LLADA2_DEFAULT_MASK_TOKEN_ID`).
+
+**Logits:** 2-D, shape ``(DRAFT_SIZE, vocab_size)``. Accepts nested sequences or
+indexable row-major objects (e.g. ``torch.Tensor``) without importing ``torch``
+in this module. Callers must not pass ``logits is None`` (non-last PP ranks return
+``None`` from the mock — the worker must not invoke the policy in that case).
+
+**``committed_token_ids``:** argmax token id for each **committed** position, in
+**increasing position order** (index ``0 .. DRAFT_SIZE-1``).
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from vllm_dllm_plugin.config import (
+    DRAFT_SIZE,
+    LLADA2_DEFAULT_COMMIT_CONFIDENCE_THRESHOLD,
+    LLADA2_DEFAULT_MASK_TOKEN_ID,
+)
+from vllm_dllm_plugin.remasking.base import (
+    RemaskStepResult,
+    validate_remask_step_result,
+)
+
+
+def _scalar_float(x: Any) -> float:
+    return float(x.item()) if hasattr(x, "item") else float(x)
+
+
+def _row(logits: Any, i: int) -> Any:
+    return logits[i]
+
+
+def _row_length(row: Any) -> int:
+    if hasattr(row, "shape"):
+        shape = row.shape
+        return int(shape[0]) if len(shape) == 1 else int(shape[-1])
+    return len(row)
+
+
+def _cell(row: Any, j: int) -> Any:
+    return row[j]
+
+
+def _logits_to_rows(logits: Any) -> list[list[float]]:
+    """Normalize 2-D logits to a list of float rows; shape ``(DRAFT_SIZE, vocab)``."""
+    n_pos = len(logits)
+    if n_pos != DRAFT_SIZE:
+        msg = f"logits first dimension must be DRAFT_SIZE={DRAFT_SIZE}, got {n_pos}"
+        raise ValueError(msg)
+    rows: list[list[float]] = []
+    vocab: int | None = None
+    for i in range(DRAFT_SIZE):
+        row = _row(logits, i)
+        vlen = _row_length(row)
+        if vlen == 0:
+            raise ValueError("logits row must be non-empty (vocab_size >= 1)")
+        if vocab is None:
+            vocab = vlen
+        elif vlen != vocab:
+            msg = f"logits rows have inconsistent vocab size: {vocab} vs {vlen}"
+            raise ValueError(msg)
+        rows.append([_scalar_float(_cell(row, j)) for j in range(vlen)])
+    return rows
+
+
+def _argmax_and_max_softmax_prob(logits_row: Sequence[float]) -> tuple[int, float]:
+    """Return argmax index and softmax probability at that index (stable softmax)."""
+    if not logits_row:
+        raise ValueError("logits row must be non-empty")
+    m = max(logits_row)
+    exps = [math.exp(x - m) for x in logits_row]
+    total = sum(exps)
+    if total <= 0.0:
+        raise ValueError("softmax normalization produced non-positive total")
+    probs = [e / total for e in exps]
+    best = max(range(len(probs)), key=lambda j: probs[j])
+    return best, probs[best]
+
+
+class Llada2DefaultRemaskingPolicy:
+    """LLaDA2.0 MVP default :class:`~vllm_dllm_plugin.remasking.RemaskingPolicy`."""
+
+    def apply(
+        self,
+        *,
+        input_block: Sequence[int],
+        logits: Any | None = None,
+        remasking_config: Mapping[str, Any] | None = None,
+    ) -> RemaskStepResult:
+        if len(input_block) != DRAFT_SIZE:
+            msg = (
+                f"input_block length must be DRAFT_SIZE={DRAFT_SIZE}, "
+                f"got {len(input_block)}"
+            )
+            raise ValueError(msg)
+        if logits is None:
+            raise ValueError(
+                "logits is required for Llada2DefaultRemaskingPolicy.apply "
+                "(callers must not pass None for non-last PP / missing logits)"
+            )
+        cfg = dict(remasking_config) if remasking_config else {}
+        threshold = float(
+            cfg.get(
+                "commit_confidence_threshold",
+                LLADA2_DEFAULT_COMMIT_CONFIDENCE_THRESHOLD,
+            ),
+        )
+        mask_token_id = int(cfg.get("mask_token_id", LLADA2_DEFAULT_MASK_TOKEN_ID))
+
+        rows = _logits_to_rows(logits)
+        committed: list[int] = []
+        next_tokens: list[int] = []
+        for row in rows:
+            token_id, conf = _argmax_and_max_softmax_prob(row)
+            if conf >= threshold:
+                committed.append(token_id)
+                next_tokens.append(token_id)
+            else:
+                next_tokens.append(mask_token_id)
+
+        result = RemaskStepResult(
+            committed_token_ids=tuple(committed),
+            next_input_block=tuple(next_tokens),
+        )
+        validate_remask_step_result(result)
+        return result

--- a/vllm_dllm_plugin/remasking/llada2_default.py
+++ b/vllm_dllm_plugin/remasking/llada2_default.py
@@ -82,16 +82,20 @@ def _logits_to_rows(logits: Any) -> list[list[float]]:
 
 
 def _argmax_and_max_softmax_prob(logits_row: Sequence[float]) -> tuple[int, float]:
-    """Return argmax index and softmax probability at that index (stable softmax)."""
+    """Return argmax index and softmax probability at that index (stable softmax).
+
+    On logit ties, the **smallest** index among maxima wins (matches common
+    ``argmax`` conventions and ``torch.argmax`` on tied values).
+    """
     if not logits_row:
         raise ValueError("logits row must be non-empty")
     m = max(logits_row)
+    best = min(j for j, x in enumerate(logits_row) if x == m)
     exps = [math.exp(x - m) for x in logits_row]
     total = sum(exps)
     if total <= 0.0:
         raise ValueError("softmax normalization produced non-positive total")
     probs = [e / total for e in exps]
-    best = max(range(len(probs)), key=lambda j: probs[j])
     return best, probs[best]
 
 

--- a/vllm_dllm_plugin/remasking/llada2_default.py
+++ b/vllm_dllm_plugin/remasking/llada2_default.py
@@ -2,6 +2,9 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """MVP default remasking policy for LLaDA2.0 (milestone issue #7).
 
+**Reference (upstream LLaDA2 model code on Hugging Face):**
+https://huggingface.co/inclusionAI/LLaDA2.0-mini/blob/main/modeling_llada2_moe.py
+
 Per-position **argmax** token and **softmax probability** at that token (stable
 softmax). Only **mask** positions participate in confidence-based transfer; decoded
 positions are preserved. Each step uses a **transfer count** from a schedule over
@@ -184,12 +187,16 @@ class Llada2DefaultRemaskingPolicy:
 
         token_ids: list[int] = []
         probs: list[float] = []
+        # Greedy token + prob at argmax per position from this block's logits; same
+        # spirit as upstream LLaDA2 per-position scores (see module docstring URL).
         for row in rows:
             tid, p = _argmax_and_max_softmax_prob(row)
             token_ids.append(tid)
             probs.append(p)
 
         neg_inf = float("-inf")
+        # Only masked draft positions get a real confidence; decoded slots must not
+        # compete in threshold / top-k selection.
         confidence = [probs[i] if masked[i] else neg_inf for i in range(DRAFT_SIZE)]
         high_conf = [
             masked[i] and (confidence[i] > threshold) for i in range(DRAFT_SIZE)


### PR DESCRIPTION
## Summary

- Add `Llada2DefaultRemaskingPolicy` (`vllm_dllm_plugin.remasking.llada2_default`): per-position argmax with **stable softmax** confidence; commit when prob ≥ threshold, else `mask_token_id` in `next_input_block`. Validates `input_block` / logits shape `(DRAFT_SIZE, vocab_size)`, duck-typed logits (no `torch` import in policy), first-index tie-break on equal top logits.
- Config defaults `LLADA2_DEFAULT_MASK_TOKEN_ID` and `LLADA2_DEFAULT_COMMIT_CONFIDENCE_THRESHOLD` (tuned for Phase 2 mock logits per `docs/MOCK_STACK_MODEL.md`).
- Tests (`tests/test_llada2_default.py`), `CONTRACTS.md` / `DESIGN_MVP.md` cross-refs, export from `remasking` package.

**Context:** [vllm-project/dllm-plugin#7](https://github.com/vllm-project/dllm-plugin/issues/7), Phase 3 in [#19](https://github.com/vllm-project/dllm-plugin/issues/19); design [DESIGN_MVP.md §8](https://github.com/vllm-project/dllm-plugin/blob/main/docs/DESIGN_MVP.md); upstream hook discussion [vllm#36155](https://github.com/vllm-project/vllm/issues/36155).

## Milestone Checklist (MVP LLaDA2.0)

- [x] Issue + phase declared (example: `Related: #20`, `Phase 0`)
- [x] HARD dependencies listed and status noted
- [x] SOFT dependencies listed and status noted
- [x] In-scope work stated
- [x] Out-of-scope work stated
- [x] Validation evidence included (tests/manual checks)
- [x] Docs impact stated (updated or N/A with reason)

### Issue and Phase

- Related issue(s): #7, #13 (follow-up only)
- Closing keyword (only if fully resolved): Closes #7
- Phase: 3

### Dependencies

- HARD: #6 (`RemaskingPolicy` / `RemaskStepResult` on `main`) — satisfied
- SOFT: #16 (additional contract tests may land later); #13 deferred to a **separate** Phase 3 PR (model→policy bridge)

### Scope

- In scope: `llada2_default.py`, config defaults, `remasking` export, unit tests, CONTRACTS/DESIGN pointers, tie-break fix commit
- Out of scope: #13 bridge module, `DllmWorker` / #10, scheduler #8, `validation.py` #4

### Validation Evidence

- Commands run: `uv run pytest -v`, `uv run pre-commit run --all-files`
- Result: 24 passed, 4 skipped (vLLM/torch `importorskip`); pre-commit passed

### Docs Impact

- Files updated: `docs/CONTRACTS.md`, `docs/DESIGN_MVP.md` (§8), `vllm_dllm_plugin/remasking/base.py` (module docstring pointer)

**AI-assisted:** Substantive implementation and tests were developed with Cursor / automated tooling; validated with local pytest and pre-commit.
