### PR TITLE
feat(remasking): connect forward logits to RemaskingPolicy (issue #13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,6 @@ Scheduler and worker classes are not implemented yet. **`register_dllm()`** alre
 - [docs/ROADMAP.md](docs/ROADMAP.md) — phased future work.
 - [docs/TOOLING.md](docs/TOOLING.md) — accurate tooling summary (pre-commit uses **`uv run`**, DCO/`sh`, run-from-root note, CI) for contributors and PR descriptions.
 
-**Forward → remasking (issue #13):** after a block forward, map last-rank logits plus `input_draft` through [`vllm_dllm_plugin.remasking.handoff`](vllm_dllm_plugin/remasking/handoff.py) (`remask_after_block_forward`). Defaults match the LLaDA2 MVP default policy unless you pass `policy=`.
-
-**CI and PyTorch:** the default [`.github/workflows/ci.yml`](.github/workflows/ci.yml) job uses `uv sync --group dev` only (no vLLM, no PyTorch). Tests that need `torch` use `pytest.importorskip("torch")` and **skip** there. The **`vllm-extra`** job syncs with `--extra vllm`, which pulls in PyTorch, so those tests **run** in that job—see [`docs/MOCK_STACK_MODEL.md`](docs/MOCK_STACK_MODEL.md) (CI section).
-
 ## License
 
 Apache License 2.0 — see [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ Scheduler and worker classes are not implemented yet. **`register_dllm()`** alre
 - [docs/ROADMAP.md](docs/ROADMAP.md) — phased future work.
 - [docs/TOOLING.md](docs/TOOLING.md) — accurate tooling summary (pre-commit uses **`uv run`**, DCO/`sh`, run-from-root note, CI) for contributors and PR descriptions.
 
+**Forward → remasking (issue #13):** after a block forward, map last-rank logits plus `input_draft` through [`vllm_dllm_plugin.remasking.handoff`](vllm_dllm_plugin/remasking/handoff.py) (`remask_after_block_forward`). Defaults match the LLaDA2 MVP default policy unless you pass `policy=`.
+
+**CI and PyTorch:** the default [`.github/workflows/ci.yml`](.github/workflows/ci.yml) job uses `uv sync --group dev` only (no vLLM, no PyTorch). Tests that need `torch` use `pytest.importorskip("torch")` and **skip** there. The **`vllm-extra`** job syncs with `--extra vllm`, which pulls in PyTorch, so those tests **run** in that job—see [`docs/MOCK_STACK_MODEL.md`](docs/MOCK_STACK_MODEL.md) (CI section).
+
 ## License
 
 Apache License 2.0 — see [LICENSE](LICENSE).

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -48,10 +48,9 @@ dLLM plugin stack (same run mode). See `DESIGN_MVP.md` section 7 (last paragraph
 
 After last-rank `compute_logits`, the worker maps block logits plus this step's
 `input_draft` into `RemaskStepResult` via
-`vllm_dllm_plugin.remasking.handoff.remask_after_block_forward`. The `policy`
-argument is optional and defaults to `Llada2DefaultRemaskingPolicy` for the LLaDA2
-MVP; pass another `RemaskingPolicy` for non-LLaDA2 stacks (see `DESIGN_MVP.md`
-section 5, forward outputs subsection).
+`vllm_dllm_plugin.remasking.handoff.remask_after_block_forward`, passing an
+explicit `RemaskingPolicy` (e.g. `Llada2DefaultRemaskingPolicy` for the LLaDA2 MVP;
+see `DESIGN_MVP.md` section 5, forward outputs subsection).
 
 - **Logits shape:** 2-D ``(DRAFT_SIZE, vocab_size)`` (or equivalent nested
   sequence). Row ``i`` matches ``input_draft[i]``. Non-last PP ranks return

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -48,8 +48,9 @@ dLLM plugin stack (same run mode). See `DESIGN_MVP.md` section 7 (last paragraph
 
 After last-rank `compute_logits`, the worker maps block logits plus this step's
 `input_draft` into `RemaskStepResult` via
-`vllm_dllm_plugin.remasking.handoff.remask_after_block_forward` (see
-`DESIGN_MVP.md` section 5, forward outputs subsection).
+`vllm_dllm_plugin.remasking.handoff.remask_after_block_forward` (must pass an
+explicit `RemaskingPolicy`, e.g. `Llada2DefaultRemaskingPolicy` for the LLaDA2
+MVP; see `DESIGN_MVP.md` section 5, forward outputs subsection).
 
 - **Logits shape:** 2-D ``(DRAFT_SIZE, vocab_size)`` (or equivalent nested
   sequence). Row ``i`` matches ``input_draft[i]``. Non-last PP ranks return

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -48,9 +48,10 @@ dLLM plugin stack (same run mode). See `DESIGN_MVP.md` section 7 (last paragraph
 
 After last-rank `compute_logits`, the worker maps block logits plus this step's
 `input_draft` into `RemaskStepResult` via
-`vllm_dllm_plugin.remasking.handoff.remask_after_block_forward` (must pass an
-explicit `RemaskingPolicy`, e.g. `Llada2DefaultRemaskingPolicy` for the LLaDA2
-MVP; see `DESIGN_MVP.md` section 5, forward outputs subsection).
+`vllm_dllm_plugin.remasking.handoff.remask_after_block_forward`. The `policy`
+argument is optional and defaults to `Llada2DefaultRemaskingPolicy` for the LLaDA2
+MVP; pass another `RemaskingPolicy` for non-LLaDA2 stacks (see `DESIGN_MVP.md`
+section 5, forward outputs subsection).
 
 - **Logits shape:** 2-D ``(DRAFT_SIZE, vocab_size)`` (or equivalent nested
   sequence). Row ``i`` matches ``input_draft[i]``. Non-last PP ranks return

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -4,10 +4,10 @@ Copy-friendly summary of **`docs/DESIGN_MVP.md` section 7** (field mapping) and
 related invariants. Keep this file ASCII-only for terminals and PR review.
 
 **Keeping docs aligned:** Edits to the field-mapping table or invariants in
-`DESIGN_MVP.md` section 7 (and closely related sections 6 and 8) should be
-mirrored here, and substantive changes here should be reflected back in
-`DESIGN_MVP.md`, so contributor copy and the canonical design doc do not drift
-silently.
+`DESIGN_MVP.md` sections 5–8 (especially 6–8 and the forward→remasking note in
+section 5) should be mirrored here, and substantive changes here should be
+reflected back in `DESIGN_MVP.md`, so contributor copy and the canonical design
+doc do not drift silently.
 
 **Upstream vLLM identifiers:** The table below uses vLLM type and member names as
 they appear for the **bounded** optional `vllm` dependency in `pyproject.toml`.
@@ -19,11 +19,11 @@ pin, re-check upstream APIs and update this file and `DESIGN_MVP.md` together
 
 | vLLM field / API | Role when dLLM plugin scheduler + worker are active |
 |------------------|-----------------------------------------------------|
-| `Request.spec_token_ids` | **Next-step input block** for the upcoming schedule. Length **`DRAFT_SIZE`** (see `vllm_dllm_plugin.config.DRAFT_SIZE`). |
-| `SchedulerOutput.scheduled_spec_decode_tokens` | **Input block** for **this** step's forward. Length **`DRAFT_SIZE`**. |
+| `Request.spec_token_ids` | Next-step **`input_draft`** for the upcoming schedule. Length **`DRAFT_SIZE`** (see `vllm_dllm_plugin.config.DRAFT_SIZE`). |
+| `SchedulerOutput.scheduled_spec_decode_tokens` | This step's **`input_draft`** for the forward. Length **`DRAFT_SIZE`**. |
 | `SchedulerOutput.num_scheduled_tokens` (per request) | Set to **`DRAFT_SIZE`** for decode steps on the block path. |
 | `ModelRunnerOutput.sampled_token_ids` | **Committed** token IDs only; length **0..`DRAFT_SIZE`** (may be empty). |
-| Worker `take_draft_token_ids()` | Returns the **next-step input block** as `DraftTokenIds` for engine -> scheduler. |
+| Worker `take_draft_token_ids()` | Returns the next-step **`input_draft`** as `DraftTokenIds` for engine -> scheduler. |
 | Scheduler `update_draft_token_ids` / `update_draft_token_ids_in_output` | Store the next block into `spec_token_ids`. **Must not** apply AR draft grammar to dLLM blocks (scheduler overrides for structured output / async). |
 
 ## Commit-0 rollback
@@ -43,6 +43,23 @@ batch the inner loop into one engine step (see `DESIGN_MVP.md` section 6).
 
 True speculative decoding on the same requests must **not** be combined with the
 dLLM plugin stack (same run mode). See `DESIGN_MVP.md` section 7 (last paragraph).
+
+## Forward to remasking handoff (issue #13)
+
+After last-rank `compute_logits`, the worker maps block logits plus this step's
+`input_draft` into `RemaskStepResult` via
+`vllm_dllm_plugin.remasking.handoff.remask_after_block_forward` (see
+`DESIGN_MVP.md` section 5, forward outputs subsection).
+
+- **Logits shape:** 2-D ``(DRAFT_SIZE, vocab_size)`` (or equivalent nested
+  sequence). Row ``i`` matches ``input_draft[i]``. Non-last PP ranks return
+  ``logits is None``; do not call the handoff there.
+- **Dtype / device:** follow the runner logits tensor; the default policy reads
+  float-like values per row.
+- **Mock path:** deterministic stub outputs for stack tests are defined in
+  issue #24 / ``docs/MOCK_STACK_MODEL.md`` and ``vllm_dllm_plugin.models.mock_llada2``.
+- **Batched 3-D logits** (leading batch axis) are **out of scope** for the MVP
+  helper; issue #10 may slice or wrap.
 
 ## One decode step (ASCII)
 

--- a/docs/DESIGN_MVP.md
+++ b/docs/DESIGN_MVP.md
@@ -116,7 +116,7 @@ flowchart LR
 
 ### Forward outputs → remasking (issue #13)
 
-**Handoff module:** `vllm_dllm_plugin.remasking.handoff` — `DllmWorker` (issue #10) should call `remask_after_block_forward` after last-rank `compute_logits`, before mapping results into `ModelRunnerOutput.sampled_token_ids` and the draft return path (sections 6–7).
+**Handoff module:** `vllm_dllm_plugin.remasking.handoff` — `DllmWorker` (issue #10) should call `remask_after_block_forward(..., policy=...)` after last-rank `compute_logits`, passing the request’s `RemaskingPolicy` (e.g. `Llada2DefaultRemaskingPolicy` for the LLaDA2 MVP), before mapping results into `ModelRunnerOutput.sampled_token_ids` and the draft return path (sections 6–7).
 
 - **Shape:** 2-D logits `(DRAFT_SIZE, vocab_size)` or an equivalent nested sequence (one row per draft position). Row index `i` aligns with `input_draft[i]` for this block.
 - **Pipeline parallel:** only the **last** rank has non-`None` logits; do not run remasking on other ranks (see `docs/MOCK_STACK_MODEL.md` and `vllm_dllm_plugin.models.mock_llada2`).

--- a/docs/DESIGN_MVP.md
+++ b/docs/DESIGN_MVP.md
@@ -116,7 +116,7 @@ flowchart LR
 
 ### Forward outputs → remasking (issue #13)
 
-**Handoff module:** `vllm_dllm_plugin.remasking.handoff` — `DllmWorker` (issue #10) should call `remask_after_block_forward(..., policy=...)` after last-rank `compute_logits`, passing the request’s `RemaskingPolicy` (e.g. `Llada2DefaultRemaskingPolicy` for the LLaDA2 MVP), before mapping results into `ModelRunnerOutput.sampled_token_ids` and the draft return path (sections 6–7).
+**Handoff module:** `vllm_dllm_plugin.remasking.handoff` — `DllmWorker` (issue #10) should call `remask_after_block_forward` after last-rank `compute_logits`, before mapping results into `ModelRunnerOutput.sampled_token_ids` and the draft return path (sections 6–7). The `policy` argument is optional and defaults to `Llada2DefaultRemaskingPolicy` for the LLaDA2 MVP; pass another `RemaskingPolicy` for other architectures.
 
 - **Shape:** 2-D logits `(DRAFT_SIZE, vocab_size)` or an equivalent nested sequence (one row per draft position). Row index `i` aligns with `input_draft[i]` for this block.
 - **Pipeline parallel:** only the **last** rank has non-`None` logits; do not run remasking on other ranks (see `docs/MOCK_STACK_MODEL.md` and `vllm_dllm_plugin.models.mock_llada2`).

--- a/docs/DESIGN_MVP.md
+++ b/docs/DESIGN_MVP.md
@@ -116,7 +116,7 @@ flowchart LR
 
 ### Forward outputs → remasking (issue #13)
 
-**Handoff module:** `vllm_dllm_plugin.remasking.handoff` — `DllmWorker` (issue #10) should call `remask_after_block_forward` after last-rank `compute_logits`, before mapping results into `ModelRunnerOutput.sampled_token_ids` and the draft return path (sections 6–7). The `policy` argument is optional and defaults to `Llada2DefaultRemaskingPolicy` for the LLaDA2 MVP; pass another `RemaskingPolicy` for other architectures.
+**Handoff module:** `vllm_dllm_plugin.remasking.handoff` — `DllmWorker` (issue #10) should call `remask_after_block_forward(..., policy=...)` after last-rank `compute_logits`, passing the request’s `RemaskingPolicy` (e.g. `Llada2DefaultRemaskingPolicy` for the LLaDA2 MVP), before mapping results into `ModelRunnerOutput.sampled_token_ids` and the draft return path (sections 6–7). The handoff does not choose a default policy.
 
 - **Shape:** 2-D logits `(DRAFT_SIZE, vocab_size)` or an equivalent nested sequence (one row per draft position). Row index `i` aligns with `input_draft[i]` for this block.
 - **Pipeline parallel:** only the **last** rank has non-`None` logits; do not run remasking on other ranks (see `docs/MOCK_STACK_MODEL.md` and `vllm_dllm_plugin.models.mock_llada2`).

--- a/docs/DESIGN_MVP.md
+++ b/docs/DESIGN_MVP.md
@@ -114,6 +114,15 @@ flowchart LR
 - **Registration** mirrors [bart-plugin](https://github.com/vllm-project/bart-plugin): one entry point that registers architecture names → qualified model class strings.
 - **Runtime** uses the same split of responsibilities: scheduler owns request state for `spec_token_ids`; worker maps `scheduled_spec_decode_tokens` to the forward and fills `sampled_token_ids` + draft return path.
 
+### Forward outputs → remasking (issue #13)
+
+**Handoff module:** `vllm_dllm_plugin.remasking.handoff` — `DllmWorker` (issue #10) should call `remask_after_block_forward` after last-rank `compute_logits`, before mapping results into `ModelRunnerOutput.sampled_token_ids` and the draft return path (sections 6–7).
+
+- **Shape:** 2-D logits `(DRAFT_SIZE, vocab_size)` or an equivalent nested sequence (one row per draft position). Row index `i` aligns with `input_draft[i]` for this block.
+- **Pipeline parallel:** only the **last** rank has non-`None` logits; do not run remasking on other ranks (see `docs/MOCK_STACK_MODEL.md` and `vllm_dllm_plugin.models.mock_llada2`).
+- **Dtype / device:** follow the logits tensor produced on the runner device; the default policy converts per-row values to Python `float` internally.
+- **Batched logits:** a leading batch dimension (e.g. `[batch, DRAFT_SIZE, vocab_size]`) is **out of scope** for the MVP helper; the worker may slice per request or add a batch-aware wrapper later.
+
 ---
 
 ## 6. One decode step (sequence)

--- a/docs/MOCK_STACK_MODEL.md
+++ b/docs/MOCK_STACK_MODEL.md
@@ -58,6 +58,10 @@ Sizes are hints for tensor shapes; the mock does not implement a real transforme
   `[num_tokens, vocab_size]` with a **non-normalized** stub (zeros plus `1.0` at
   index `0`). Suitable for shape/device/dtype checks and degenerate argmax bias;
   not a proper probability distribution for logprob or diversity assertions.
+  For the MVP **block** path consumed by
+  `vllm_dllm_plugin.remasking.handoff` ([issue #13](https://github.com/vllm-project/dllm-plugin/issues/13)),
+  `num_tokens` must equal **`DRAFT_SIZE`** so each row aligns with one position
+  in this step's `input_draft`.
 
 **Remasking unit tests:** `Llada2DefaultRemaskingPolicy` expects drafts that use
 the configured **mask token id** (see `LLADA2_DEFAULT_MASK_TOKEN_ID` in

--- a/docs/MOCK_STACK_MODEL.md
+++ b/docs/MOCK_STACK_MODEL.md
@@ -82,3 +82,8 @@ job syncs with `--extra vllm` on Python 3.12 and runs **pytest** (lint already
 ran in the main matrix) so registration and mock import are exercised on PRs. If
 that job fails (e.g. no wheel for the runner), use the **Optional vLLM smoke**
 workflow or `uv sync --group dev --extra vllm` locally.
+
+**PyTorch-dependent tests:** `tests/test_remask_forward_handoff.py` uses
+`pytest.importorskip("torch")` for tensor-shape cases; they **skip** in the
+default matrix (no PyTorch) and **run** in the `vllm-extra` job, which installs
+Torch transitively via the `vllm` extra.

--- a/tests/test_remask_forward_handoff.py
+++ b/tests/test_remask_forward_handoff.py
@@ -87,7 +87,7 @@ def test_omit_policy_matches_explicit_llada2_default() -> None:
     assert explicit == defaulted
 
 
-def test_custom_policy_passed_through() -> None:
+def test_explicit_policy_passed_through() -> None:
     policy = Llada2DefaultRemaskingPolicy()
     draft = _draft_all_mask()
     logits = _mock_logits()

--- a/tests/test_remask_forward_handoff.py
+++ b/tests/test_remask_forward_handoff.py
@@ -3,6 +3,9 @@
 """Tests for ``vllm_dllm_plugin.remasking.handoff`` (issue #13).
 
 Broader field-mapping / worker-runner contract coverage lives in issue #16.
+Tensor-shape tests use ``pytest.importorskip("torch")``; they skip in the default
+dev sync (no PyTorch) and run in the CI ``vllm-extra`` job, which installs
+``--extra vllm`` (Torch is a transitive dependency of vLLM).
 """
 
 from __future__ import annotations
@@ -32,30 +35,19 @@ def _mock_logits(*, vocab_size: int = 256) -> list[list[float]]:
     return [_mock_stub_row(vocab_size=vocab_size) for _ in range(DRAFT_SIZE)]
 
 
-@pytest.fixture
-def llada2_policy() -> Llada2DefaultRemaskingPolicy:
-    return Llada2DefaultRemaskingPolicy()
-
-
-def test_remask_rejects_wrong_input_draft_length(
-    llada2_policy: Llada2DefaultRemaskingPolicy,
-) -> None:
+def test_remask_rejects_wrong_input_draft_length() -> None:
     with pytest.raises(ValueError, match="input_draft length"):
         remask_after_block_forward(
             input_draft=(0,) * (DRAFT_SIZE - 1),
             logits=_mock_logits(),
-            policy=llada2_policy,
         )
 
 
-def test_remask_rejects_logits_none(
-    llada2_policy: Llada2DefaultRemaskingPolicy,
-) -> None:
+def test_remask_rejects_logits_none() -> None:
     with pytest.raises(ValueError, match="logits is None"):
         remask_after_block_forward(
             input_draft=_draft_all_mask(),
             logits=None,
-            policy=llada2_policy,
         )
 
 
@@ -70,43 +62,53 @@ def test_assert_block_logits_shape_rejects_none() -> None:
         assert_block_logits_shape(None)
 
 
-def test_mock_shaped_logits_terminal_matches_direct_policy_apply(
-    llada2_policy: Llada2DefaultRemaskingPolicy,
-) -> None:
+def test_mock_shaped_logits_terminal_matches_direct_policy_apply() -> None:
     draft = _draft_all_mask()
     logits = _mock_logits(vocab_size=256)
-    direct = llada2_policy.apply(
+    policy = Llada2DefaultRemaskingPolicy()
+    direct = policy.apply(
         input_draft=draft,
         logits=logits,
     )
-    via = remask_after_block_forward(
-        input_draft=draft,
-        logits=logits,
-        policy=llada2_policy,
-    )
+    via = remask_after_block_forward(input_draft=draft, logits=logits)
     validate_remask_step_result(via)
     assert via == direct
 
 
-def test_torch_tensor_logits_matches_list_path(
-    llada2_policy: Llada2DefaultRemaskingPolicy,
-) -> None:
+def test_omit_policy_matches_explicit_llada2_default() -> None:
+    draft = _draft_all_mask()
+    logits = _mock_logits()
+    explicit = remask_after_block_forward(
+        input_draft=draft,
+        logits=logits,
+        policy=Llada2DefaultRemaskingPolicy(),
+    )
+    defaulted = remask_after_block_forward(input_draft=draft, logits=logits)
+    assert explicit == defaulted
+
+
+def test_custom_policy_passed_through() -> None:
+    policy = Llada2DefaultRemaskingPolicy()
+    draft = _draft_all_mask()
+    logits = _mock_logits()
+    out = remask_after_block_forward(
+        input_draft=draft,
+        logits=logits,
+        policy=policy,
+    )
+    validate_remask_step_result(out)
+    assert out.committed_token_ids == (0,) * DRAFT_SIZE
+
+
+def test_torch_tensor_logits_matches_list_path() -> None:
     torch = pytest.importorskip("torch")
     draft = _draft_all_mask()
     vocab = 256
     logits_t = torch.zeros(DRAFT_SIZE, vocab, dtype=torch.float32)
     logits_t[:, 0] = 1.0
     logits_list = _mock_logits(vocab_size=vocab)
-    out_t = remask_after_block_forward(
-        input_draft=draft,
-        logits=logits_t,
-        policy=llada2_policy,
-    )
-    out_list = remask_after_block_forward(
-        input_draft=draft,
-        logits=logits_list,
-        policy=llada2_policy,
-    )
+    out_t = remask_after_block_forward(input_draft=draft, logits=logits_t)
+    out_list = remask_after_block_forward(input_draft=draft, logits=logits_list)
     assert out_t == out_list
 
 
@@ -117,14 +119,8 @@ def test_assert_block_logits_shape_rejects_wrong_tensor_rank() -> None:
         assert_block_logits_shape(bad)
 
 
-def test_remask_rejects_wrong_tensor_first_dim(
-    llada2_policy: Llada2DefaultRemaskingPolicy,
-) -> None:
+def test_remask_rejects_wrong_tensor_first_dim() -> None:
     torch = pytest.importorskip("torch")
     bad = torch.zeros(DRAFT_SIZE + 1, 128)
     with pytest.raises(ValueError, match="DRAFT_SIZE"):
-        remask_after_block_forward(
-            input_draft=_draft_all_mask(),
-            logits=bad,
-            policy=llada2_policy,
-        )
+        remask_after_block_forward(input_draft=_draft_all_mask(), logits=bad)

--- a/tests/test_remask_forward_handoff.py
+++ b/tests/test_remask_forward_handoff.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for ``vllm_dllm_plugin.remasking.handoff`` (issue #13).
+
+Broader field-mapping / worker-runner contract coverage lives in issue #16.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vllm_dllm_plugin.config import DRAFT_SIZE, LLADA2_DEFAULT_MASK_TOKEN_ID
+from vllm_dllm_plugin.remasking import (
+    Llada2DefaultRemaskingPolicy,
+    assert_block_logits_shape,
+    remask_after_block_forward,
+    validate_remask_step_result,
+)
+
+
+def _draft_all_mask() -> tuple[int, ...]:
+    return (LLADA2_DEFAULT_MASK_TOKEN_ID,) * DRAFT_SIZE
+
+
+def _mock_stub_row(*, vocab_size: int = 256) -> list[float]:
+    row = [0.0] * vocab_size
+    row[0] = 1.0
+    return row
+
+
+def _mock_logits(*, vocab_size: int = 256) -> list[list[float]]:
+    return [_mock_stub_row(vocab_size=vocab_size) for _ in range(DRAFT_SIZE)]
+
+
+def test_remask_rejects_wrong_input_draft_length() -> None:
+    with pytest.raises(ValueError, match="input_draft length"):
+        remask_after_block_forward(
+            input_draft=(0,) * (DRAFT_SIZE - 1),
+            logits=_mock_logits(),
+        )
+
+
+def test_remask_rejects_logits_none() -> None:
+    with pytest.raises(ValueError, match="logits is None"):
+        remask_after_block_forward(
+            input_draft=_draft_all_mask(),
+            logits=None,
+        )
+
+
+def test_assert_block_logits_shape_rejects_wrong_len_sequence() -> None:
+    short = [_mock_stub_row() for _ in range(DRAFT_SIZE - 1)]
+    with pytest.raises(ValueError, match="DRAFT_SIZE"):
+        assert_block_logits_shape(short)
+
+
+def test_assert_block_logits_shape_rejects_none() -> None:
+    with pytest.raises(ValueError, match="logits is None"):
+        assert_block_logits_shape(None)
+
+
+def test_mock_shaped_logits_terminal_matches_direct_policy_apply() -> None:
+    draft = _draft_all_mask()
+    logits = _mock_logits(vocab_size=256)
+    direct = Llada2DefaultRemaskingPolicy().apply(
+        input_draft=draft,
+        logits=logits,
+    )
+    via = remask_after_block_forward(input_draft=draft, logits=logits)
+    validate_remask_step_result(via)
+    assert via == direct
+
+
+def test_custom_policy_passed_through() -> None:
+    policy = Llada2DefaultRemaskingPolicy()
+    draft = _draft_all_mask()
+    logits = _mock_logits()
+    out = remask_after_block_forward(
+        input_draft=draft,
+        logits=logits,
+        policy=policy,
+    )
+    validate_remask_step_result(out)
+    assert out.committed_token_ids == (0,) * DRAFT_SIZE
+
+
+def test_torch_tensor_logits_matches_list_path() -> None:
+    torch = pytest.importorskip("torch")
+    draft = _draft_all_mask()
+    vocab = 256
+    logits_t = torch.zeros(DRAFT_SIZE, vocab, dtype=torch.float32)
+    logits_t[:, 0] = 1.0
+    logits_list = _mock_logits(vocab_size=vocab)
+    out_t = remask_after_block_forward(input_draft=draft, logits=logits_t)
+    out_list = remask_after_block_forward(input_draft=draft, logits=logits_list)
+    assert out_t == out_list
+
+
+def test_assert_block_logits_shape_rejects_wrong_tensor_rank() -> None:
+    torch = pytest.importorskip("torch")
+    bad = torch.zeros(DRAFT_SIZE, 16, 16)
+    with pytest.raises(ValueError, match="2-D"):
+        assert_block_logits_shape(bad)
+
+
+def test_remask_rejects_wrong_tensor_first_dim() -> None:
+    torch = pytest.importorskip("torch")
+    bad = torch.zeros(DRAFT_SIZE + 1, 128)
+    with pytest.raises(ValueError, match="DRAFT_SIZE"):
+        remask_after_block_forward(input_draft=_draft_all_mask(), logits=bad)

--- a/tests/test_remask_forward_handoff.py
+++ b/tests/test_remask_forward_handoff.py
@@ -10,11 +10,15 @@ dev sync (no PyTorch) and run in the CI ``vllm-extra`` job, which installs
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
+from typing import Any
+
 import pytest
 
 from vllm_dllm_plugin.config import DRAFT_SIZE, LLADA2_DEFAULT_MASK_TOKEN_ID
 from vllm_dllm_plugin.remasking import (
     Llada2DefaultRemaskingPolicy,
+    RemaskStepResult,
     assert_block_logits_shape,
     remask_after_block_forward,
     validate_remask_step_result,
@@ -35,19 +39,49 @@ def _mock_logits(*, vocab_size: int = 256) -> list[list[float]]:
     return [_mock_stub_row(vocab_size=vocab_size) for _ in range(DRAFT_SIZE)]
 
 
-def test_remask_rejects_wrong_input_draft_length() -> None:
+@pytest.fixture
+def llada2_policy() -> Llada2DefaultRemaskingPolicy:
+    return Llada2DefaultRemaskingPolicy()
+
+
+class _StubRemaskingPolicy:
+    """Distinct from Llada2DefaultRemaskingPolicy; proves ``policy=`` is used."""
+
+    __test__ = False
+
+    def apply(
+        self,
+        *,
+        input_draft: Sequence[int],
+        logits: Any | None = None,
+        remasking_config: Mapping[str, Any] | None = None,
+    ) -> RemaskStepResult:
+        del input_draft, logits, remasking_config
+        return RemaskStepResult(
+            committed_token_ids=(123, 456),
+            next_input_block=(99,) * DRAFT_SIZE,
+        )
+
+
+def test_remask_rejects_wrong_input_draft_length(
+    llada2_policy: Llada2DefaultRemaskingPolicy,
+) -> None:
     with pytest.raises(ValueError, match="input_draft length"):
         remask_after_block_forward(
             input_draft=(0,) * (DRAFT_SIZE - 1),
             logits=_mock_logits(),
+            policy=llada2_policy,
         )
 
 
-def test_remask_rejects_logits_none() -> None:
+def test_remask_rejects_logits_none(
+    llada2_policy: Llada2DefaultRemaskingPolicy,
+) -> None:
     with pytest.raises(ValueError, match="logits is None"):
         remask_after_block_forward(
             input_draft=_draft_all_mask(),
             logits=None,
+            policy=llada2_policy,
         )
 
 
@@ -62,53 +96,74 @@ def test_assert_block_logits_shape_rejects_none() -> None:
         assert_block_logits_shape(None)
 
 
-def test_mock_shaped_logits_terminal_matches_direct_policy_apply() -> None:
+def test_mock_shaped_logits_terminal_matches_direct_policy_apply(
+    llada2_policy: Llada2DefaultRemaskingPolicy,
+) -> None:
     draft = _draft_all_mask()
     logits = _mock_logits(vocab_size=256)
-    policy = Llada2DefaultRemaskingPolicy()
-    direct = policy.apply(
+    direct = llada2_policy.apply(
         input_draft=draft,
         logits=logits,
     )
-    via = remask_after_block_forward(input_draft=draft, logits=logits)
+    via = remask_after_block_forward(
+        input_draft=draft,
+        logits=logits,
+        policy=llada2_policy,
+    )
     validate_remask_step_result(via)
     assert via == direct
 
 
-def test_omit_policy_matches_explicit_llada2_default() -> None:
-    draft = _draft_all_mask()
-    logits = _mock_logits()
-    explicit = remask_after_block_forward(
-        input_draft=draft,
-        logits=logits,
-        policy=Llada2DefaultRemaskingPolicy(),
-    )
-    defaulted = remask_after_block_forward(input_draft=draft, logits=logits)
-    assert explicit == defaulted
-
-
-def test_explicit_policy_passed_through() -> None:
-    policy = Llada2DefaultRemaskingPolicy()
-    draft = _draft_all_mask()
-    logits = _mock_logits()
+def test_stub_policy_passed_through() -> None:
+    stub = _StubRemaskingPolicy()
     out = remask_after_block_forward(
+        input_draft=_draft_all_mask(),
+        logits=_mock_logits(),
+        policy=stub,
+    )
+    assert out.committed_token_ids == (123, 456)
+    assert out.next_input_block == (99,) * DRAFT_SIZE
+
+
+def test_remasking_config_forwarded_to_policy(
+    llada2_policy: Llada2DefaultRemaskingPolicy,
+) -> None:
+    draft = _draft_all_mask()
+    logits = _mock_logits()
+    cfg = {"num_transfer": 1}
+    direct = llada2_policy.apply(
         input_draft=draft,
         logits=logits,
-        policy=policy,
+        remasking_config=cfg,
     )
-    validate_remask_step_result(out)
-    assert out.committed_token_ids == (0,) * DRAFT_SIZE
+    via = remask_after_block_forward(
+        input_draft=draft,
+        logits=logits,
+        policy=llada2_policy,
+        remasking_config=cfg,
+    )
+    assert via == direct
 
 
-def test_torch_tensor_logits_matches_list_path() -> None:
+def test_torch_tensor_logits_matches_list_path(
+    llada2_policy: Llada2DefaultRemaskingPolicy,
+) -> None:
     torch = pytest.importorskip("torch")
     draft = _draft_all_mask()
     vocab = 256
     logits_t = torch.zeros(DRAFT_SIZE, vocab, dtype=torch.float32)
     logits_t[:, 0] = 1.0
     logits_list = _mock_logits(vocab_size=vocab)
-    out_t = remask_after_block_forward(input_draft=draft, logits=logits_t)
-    out_list = remask_after_block_forward(input_draft=draft, logits=logits_list)
+    out_t = remask_after_block_forward(
+        input_draft=draft,
+        logits=logits_t,
+        policy=llada2_policy,
+    )
+    out_list = remask_after_block_forward(
+        input_draft=draft,
+        logits=logits_list,
+        policy=llada2_policy,
+    )
     assert out_t == out_list
 
 
@@ -119,8 +174,14 @@ def test_assert_block_logits_shape_rejects_wrong_tensor_rank() -> None:
         assert_block_logits_shape(bad)
 
 
-def test_remask_rejects_wrong_tensor_first_dim() -> None:
+def test_remask_rejects_wrong_tensor_first_dim(
+    llada2_policy: Llada2DefaultRemaskingPolicy,
+) -> None:
     torch = pytest.importorskip("torch")
     bad = torch.zeros(DRAFT_SIZE + 1, 128)
     with pytest.raises(ValueError, match="DRAFT_SIZE"):
-        remask_after_block_forward(input_draft=_draft_all_mask(), logits=bad)
+        remask_after_block_forward(
+            input_draft=_draft_all_mask(),
+            logits=bad,
+            policy=llada2_policy,
+        )

--- a/tests/test_remask_forward_handoff.py
+++ b/tests/test_remask_forward_handoff.py
@@ -32,19 +32,30 @@ def _mock_logits(*, vocab_size: int = 256) -> list[list[float]]:
     return [_mock_stub_row(vocab_size=vocab_size) for _ in range(DRAFT_SIZE)]
 
 
-def test_remask_rejects_wrong_input_draft_length() -> None:
+@pytest.fixture
+def llada2_policy() -> Llada2DefaultRemaskingPolicy:
+    return Llada2DefaultRemaskingPolicy()
+
+
+def test_remask_rejects_wrong_input_draft_length(
+    llada2_policy: Llada2DefaultRemaskingPolicy,
+) -> None:
     with pytest.raises(ValueError, match="input_draft length"):
         remask_after_block_forward(
             input_draft=(0,) * (DRAFT_SIZE - 1),
             logits=_mock_logits(),
+            policy=llada2_policy,
         )
 
 
-def test_remask_rejects_logits_none() -> None:
+def test_remask_rejects_logits_none(
+    llada2_policy: Llada2DefaultRemaskingPolicy,
+) -> None:
     with pytest.raises(ValueError, match="logits is None"):
         remask_after_block_forward(
             input_draft=_draft_all_mask(),
             logits=None,
+            policy=llada2_policy,
         )
 
 
@@ -59,40 +70,43 @@ def test_assert_block_logits_shape_rejects_none() -> None:
         assert_block_logits_shape(None)
 
 
-def test_mock_shaped_logits_terminal_matches_direct_policy_apply() -> None:
+def test_mock_shaped_logits_terminal_matches_direct_policy_apply(
+    llada2_policy: Llada2DefaultRemaskingPolicy,
+) -> None:
     draft = _draft_all_mask()
     logits = _mock_logits(vocab_size=256)
-    direct = Llada2DefaultRemaskingPolicy().apply(
+    direct = llada2_policy.apply(
         input_draft=draft,
         logits=logits,
     )
-    via = remask_after_block_forward(input_draft=draft, logits=logits)
+    via = remask_after_block_forward(
+        input_draft=draft,
+        logits=logits,
+        policy=llada2_policy,
+    )
     validate_remask_step_result(via)
     assert via == direct
 
 
-def test_custom_policy_passed_through() -> None:
-    policy = Llada2DefaultRemaskingPolicy()
-    draft = _draft_all_mask()
-    logits = _mock_logits()
-    out = remask_after_block_forward(
-        input_draft=draft,
-        logits=logits,
-        policy=policy,
-    )
-    validate_remask_step_result(out)
-    assert out.committed_token_ids == (0,) * DRAFT_SIZE
-
-
-def test_torch_tensor_logits_matches_list_path() -> None:
+def test_torch_tensor_logits_matches_list_path(
+    llada2_policy: Llada2DefaultRemaskingPolicy,
+) -> None:
     torch = pytest.importorskip("torch")
     draft = _draft_all_mask()
     vocab = 256
     logits_t = torch.zeros(DRAFT_SIZE, vocab, dtype=torch.float32)
     logits_t[:, 0] = 1.0
     logits_list = _mock_logits(vocab_size=vocab)
-    out_t = remask_after_block_forward(input_draft=draft, logits=logits_t)
-    out_list = remask_after_block_forward(input_draft=draft, logits=logits_list)
+    out_t = remask_after_block_forward(
+        input_draft=draft,
+        logits=logits_t,
+        policy=llada2_policy,
+    )
+    out_list = remask_after_block_forward(
+        input_draft=draft,
+        logits=logits_list,
+        policy=llada2_policy,
+    )
     assert out_t == out_list
 
 
@@ -103,8 +117,14 @@ def test_assert_block_logits_shape_rejects_wrong_tensor_rank() -> None:
         assert_block_logits_shape(bad)
 
 
-def test_remask_rejects_wrong_tensor_first_dim() -> None:
+def test_remask_rejects_wrong_tensor_first_dim(
+    llada2_policy: Llada2DefaultRemaskingPolicy,
+) -> None:
     torch = pytest.importorskip("torch")
     bad = torch.zeros(DRAFT_SIZE + 1, 128)
     with pytest.raises(ValueError, match="DRAFT_SIZE"):
-        remask_after_block_forward(input_draft=_draft_all_mask(), logits=bad)
+        remask_after_block_forward(
+            input_draft=_draft_all_mask(),
+            logits=bad,
+            policy=llada2_policy,
+        )

--- a/vllm_dllm_plugin/models/mock_llada2.py
+++ b/vllm_dllm_plugin/models/mock_llada2.py
@@ -11,8 +11,8 @@ shape / device / dtype / argmax-bias checks, not for tests that assume a proper
 softmax distribution or diverse sampling. On the last PP rank the logit matrix
 has shape ``(num_tokens, vocab_size)``; for the MVP block handoff (issue #13,
 ``vllm_dllm_plugin.remasking.handoff``), ``num_tokens`` must match ``DRAFT_SIZE``.
-Issue #10 should call ``remask_after_block_forward`` after ``compute_logits``
-(optional ``policy=``; defaults to ``Llada2DefaultRemaskingPolicy`` for the MVP).
+Issue #10 should call ``remask_after_block_forward(..., policy=...)`` after
+``compute_logits``, passing the stack's ``RemaskingPolicy``.
 
 There is **no** ``make_empty_intermediate_tensors``; PP-shaped executor paths may
 fail before ``forward`` until DllmWorker / model parity work (milestone issue

--- a/vllm_dllm_plugin/models/mock_llada2.py
+++ b/vllm_dllm_plugin/models/mock_llada2.py
@@ -8,7 +8,10 @@ in issue #12 (Phase 7). Requires a working ``vllm`` + ``torch`` install.
 **Outputs:** ``forward`` returns last-hidden-shaped tensors; ``compute_logits``
 returns a **non-normalized** logit vector (zeros plus a 1.0 at index 0)—fine for
 shape / device / dtype / argmax-bias checks, not for tests that assume a proper
-softmax distribution or diverse sampling.
+softmax distribution or diverse sampling. On the last PP rank the logit matrix
+has shape ``(num_tokens, vocab_size)``; for the MVP block handoff (issue #13,
+``vllm_dllm_plugin.remasking.handoff``), ``num_tokens`` must match ``DRAFT_SIZE``.
+Issue #10 should call ``remask_after_block_forward`` after ``compute_logits``.
 
 There is **no** ``make_empty_intermediate_tensors``; PP-shaped executor paths may
 fail before ``forward`` until DllmWorker / model parity work (milestone issue

--- a/vllm_dllm_plugin/models/mock_llada2.py
+++ b/vllm_dllm_plugin/models/mock_llada2.py
@@ -11,7 +11,8 @@ shape / device / dtype / argmax-bias checks, not for tests that assume a proper
 softmax distribution or diverse sampling. On the last PP rank the logit matrix
 has shape ``(num_tokens, vocab_size)``; for the MVP block handoff (issue #13,
 ``vllm_dllm_plugin.remasking.handoff``), ``num_tokens`` must match ``DRAFT_SIZE``.
-Issue #10 should call ``remask_after_block_forward`` after ``compute_logits``.
+Issue #10 should call ``remask_after_block_forward(..., policy=...)`` after
+``compute_logits``, passing the stack's ``RemaskingPolicy``.
 
 There is **no** ``make_empty_intermediate_tensors``; PP-shaped executor paths may
 fail before ``forward`` until DllmWorker / model parity work (milestone issue

--- a/vllm_dllm_plugin/models/mock_llada2.py
+++ b/vllm_dllm_plugin/models/mock_llada2.py
@@ -11,8 +11,8 @@ shape / device / dtype / argmax-bias checks, not for tests that assume a proper
 softmax distribution or diverse sampling. On the last PP rank the logit matrix
 has shape ``(num_tokens, vocab_size)``; for the MVP block handoff (issue #13,
 ``vllm_dllm_plugin.remasking.handoff``), ``num_tokens`` must match ``DRAFT_SIZE``.
-Issue #10 should call ``remask_after_block_forward(..., policy=...)`` after
-``compute_logits``, passing the stack's ``RemaskingPolicy``.
+Issue #10 should call ``remask_after_block_forward`` after ``compute_logits``
+(optional ``policy=``; defaults to ``Llada2DefaultRemaskingPolicy`` for the MVP).
 
 There is **no** ``make_empty_intermediate_tensors``; PP-shaped executor paths may
 fail before ``forward`` until DllmWorker / model parity work (milestone issue

--- a/vllm_dllm_plugin/remasking/__init__.py
+++ b/vllm_dllm_plugin/remasking/__init__.py
@@ -9,11 +9,17 @@ from vllm_dllm_plugin.remasking.base import (
     RemaskStepResult,
     validate_remask_step_result,
 )
+from vllm_dllm_plugin.remasking.handoff import (
+    assert_block_logits_shape,
+    remask_after_block_forward,
+)
 from vllm_dllm_plugin.remasking.llada2_default import Llada2DefaultRemaskingPolicy
 
 __all__ = [
     "Llada2DefaultRemaskingPolicy",
     "RemaskStepResult",
     "RemaskingPolicy",
+    "assert_block_logits_shape",
+    "remask_after_block_forward",
     "validate_remask_step_result",
 ]

--- a/vllm_dllm_plugin/remasking/handoff.py
+++ b/vllm_dllm_plugin/remasking/handoff.py
@@ -28,7 +28,6 @@ from vllm_dllm_plugin.remasking.base import (
     RemaskStepResult,
     validate_remask_step_result,
 )
-from vllm_dllm_plugin.remasking.llada2_default import Llada2DefaultRemaskingPolicy
 
 
 def assert_block_logits_shape(logits: Any) -> None:
@@ -64,8 +63,8 @@ def remask_after_block_forward(
     *,
     input_draft: Sequence[int],
     logits: Any,
+    policy: RemaskingPolicy,
     remasking_config: Mapping[str, Any] | None = None,
-    policy: RemaskingPolicy | None = None,
 ) -> RemaskStepResult:
     """Run one remasking step after a single-block forward (milestone issue #13).
 
@@ -79,9 +78,11 @@ def remask_after_block_forward(
         input_draft: This step's draft, length ``DRAFT_SIZE`` (aligned with
             ``scheduled_spec_decode_tokens``).
         logits: Non-``None`` block logits, 2-D ``(DRAFT_SIZE, vocab_size)``.
+        policy: Concrete remasking implementation (e.g.
+            :class:`~vllm_dllm_plugin.remasking.Llada2DefaultRemaskingPolicy` for
+            the LLaDA2 MVP stack). Callers must not omit this—there is no default
+            policy for arbitrary architectures.
         remasking_config: Optional knobs for the concrete policy.
-        policy: Defaults to
-            :class:`~vllm_dllm_plugin.remasking.Llada2DefaultRemaskingPolicy`.
 
     Returns:
         Validated :class:`~vllm_dllm_plugin.remasking.RemaskStepResult`.
@@ -103,10 +104,7 @@ def remask_after_block_forward(
         )
         raise ValueError(msg)
     assert_block_logits_shape(logits)
-    pol: RemaskingPolicy = (
-        policy if policy is not None else Llada2DefaultRemaskingPolicy()
-    )
-    result = pol.apply(
+    result = policy.apply(
         input_draft=input_draft,
         logits=logits,
         remasking_config=remasking_config,

--- a/vllm_dllm_plugin/remasking/handoff.py
+++ b/vllm_dllm_plugin/remasking/handoff.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Forward output to :class:`~vllm_dllm_plugin.remasking.RemaskingPolicy` (issue #13).
+
+After one block forward on the **last** pipeline-parallel rank, ``compute_logits``
+(see :mod:`vllm_dllm_plugin.models.mock_llada2` and ``docs/MOCK_STACK_MODEL.md``)
+must yield a **2-D** tensor of shape ``(DRAFT_SIZE, vocab_size)`` (or an
+equivalent nested sequence). Row ``i`` aligns with ``input_draft[i]``.
+
+**Out of scope for this MVP helper:** a leading batch dimension (e.g.
+``[batch, DRAFT_SIZE, vocab]``). Issue #10 may slice per request or add a
+batch-aware wrapper.
+
+Non-last PP ranks return ``logits is None``; do **not** call this module in that
+case—there is nothing to remask until the final stage.
+
+See ``docs/DESIGN_MVP.md`` §5–8 and ``docs/CONTRACTS.md`` (forward → remasking).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from vllm_dllm_plugin.config import DRAFT_SIZE
+from vllm_dllm_plugin.remasking.base import (
+    RemaskingPolicy,
+    RemaskStepResult,
+    validate_remask_step_result,
+)
+from vllm_dllm_plugin.remasking.llada2_default import Llada2DefaultRemaskingPolicy
+
+
+def assert_block_logits_shape(logits: Any) -> None:
+    """Require 2-D block logits with first dimension ``DRAFT_SIZE``.
+
+    Accepts ``torch.Tensor`` (via ``shape``) or a length-``DRAFT_SIZE`` sequence
+    of per-position rows without importing ``torch``.
+    """
+    if logits is None:
+        msg = "logits is None (unexpected after caller guard)"
+        raise ValueError(msg)
+    if hasattr(logits, "shape"):
+        shape = logits.shape
+        ndim = len(shape)
+        if ndim != 2:
+            msg = (
+                "block logits must be 2-D with shape (DRAFT_SIZE, vocab_size); "
+                f"got ndim={ndim} shape={tuple(int(x) for x in shape)}"
+            )
+            raise ValueError(msg)
+        n0 = int(shape[0])
+        if n0 != DRAFT_SIZE:
+            msg = f"logits first dimension must be DRAFT_SIZE={DRAFT_SIZE}, got {n0}"
+            raise ValueError(msg)
+        return
+    n_pos = len(logits)
+    if n_pos != DRAFT_SIZE:
+        msg = f"logits first dimension must be DRAFT_SIZE={DRAFT_SIZE}, got {n_pos}"
+        raise ValueError(msg)
+
+
+def remask_after_block_forward(
+    *,
+    input_draft: Sequence[int],
+    logits: Any,
+    remasking_config: Mapping[str, Any] | None = None,
+    policy: RemaskingPolicy | None = None,
+) -> RemaskStepResult:
+    """Run one remasking step after a single-block forward (milestone issue #13).
+
+    Intended call site: ``DllmWorker`` (issue #10) after last-rank
+    ``compute_logits``, before mapping
+    :class:`~vllm_dllm_plugin.remasking.RemaskStepResult` into
+    ``ModelRunnerOutput.sampled_token_ids`` and the draft return path
+    (``docs/DESIGN_MVP.md`` §6–7).
+
+    Args:
+        input_draft: This step's draft, length ``DRAFT_SIZE`` (aligned with
+            ``scheduled_spec_decode_tokens``).
+        logits: Non-``None`` block logits, 2-D ``(DRAFT_SIZE, vocab_size)``.
+        remasking_config: Optional knobs for the concrete policy.
+        policy: Defaults to
+            :class:`~vllm_dllm_plugin.remasking.Llada2DefaultRemaskingPolicy`.
+
+    Returns:
+        Validated :class:`~vllm_dllm_plugin.remasking.RemaskStepResult`.
+
+    Raises:
+        ValueError: If ``input_draft`` length is wrong, ``logits`` is ``None``,
+            or logits fail :func:`assert_block_logits_shape`.
+    """
+    if len(input_draft) != DRAFT_SIZE:
+        msg = (
+            f"input_draft length must be DRAFT_SIZE={DRAFT_SIZE}, "
+            f"got {len(input_draft)}"
+        )
+        raise ValueError(msg)
+    if logits is None:
+        msg = (
+            "logits is None; remasking applies only on the last pipeline-parallel "
+            "rank where compute_logits returns a tensor (see docs/MOCK_STACK_MODEL.md)."
+        )
+        raise ValueError(msg)
+    assert_block_logits_shape(logits)
+    pol: RemaskingPolicy = (
+        policy if policy is not None else Llada2DefaultRemaskingPolicy()
+    )
+    result = pol.apply(
+        input_draft=input_draft,
+        logits=logits,
+        remasking_config=remasking_config,
+    )
+    validate_remask_step_result(result)
+    return result
+
+
+__all__ = [
+    "assert_block_logits_shape",
+    "remask_after_block_forward",
+]

--- a/vllm_dllm_plugin/remasking/handoff.py
+++ b/vllm_dllm_plugin/remasking/handoff.py
@@ -28,6 +28,7 @@ from vllm_dllm_plugin.remasking.base import (
     RemaskStepResult,
     validate_remask_step_result,
 )
+from vllm_dllm_plugin.remasking.llada2_default import Llada2DefaultRemaskingPolicy
 
 
 def assert_block_logits_shape(logits: Any) -> None:
@@ -35,6 +36,11 @@ def assert_block_logits_shape(logits: Any) -> None:
 
     Accepts ``torch.Tensor`` (via ``shape``) or a length-``DRAFT_SIZE`` sequence
     of per-position rows without importing ``torch``.
+
+    For nested sequences, only the **outer** length is checked here; consistent
+    per-row vocabulary width is enforced by the concrete policy (e.g.
+    :class:`~vllm_dllm_plugin.remasking.Llada2DefaultRemaskingPolicy` via
+    ``_logits_to_rows``), not by this helper.
     """
     if logits is None:
         msg = "logits is None (unexpected after caller guard)"
@@ -63,8 +69,8 @@ def remask_after_block_forward(
     *,
     input_draft: Sequence[int],
     logits: Any,
-    policy: RemaskingPolicy,
     remasking_config: Mapping[str, Any] | None = None,
+    policy: RemaskingPolicy | None = None,
 ) -> RemaskStepResult:
     """Run one remasking step after a single-block forward (milestone issue #13).
 
@@ -78,11 +84,11 @@ def remask_after_block_forward(
         input_draft: This step's draft, length ``DRAFT_SIZE`` (aligned with
             ``scheduled_spec_decode_tokens``).
         logits: Non-``None`` block logits, 2-D ``(DRAFT_SIZE, vocab_size)``.
-        policy: Concrete remasking implementation (e.g.
-            :class:`~vllm_dllm_plugin.remasking.Llada2DefaultRemaskingPolicy` for
-            the LLaDA2 MVP stack). Callers must not omit this—there is no default
-            policy for arbitrary architectures.
         remasking_config: Optional knobs for the concrete policy.
+        policy: Optional :class:`~vllm_dllm_plugin.remasking.RemaskingPolicy`.
+            Defaults to
+            :class:`~vllm_dllm_plugin.remasking.Llada2DefaultRemaskingPolicy` for
+            the LLaDA2 MVP; pass another implementation for non-LLaDA2 stacks.
 
     Returns:
         Validated :class:`~vllm_dllm_plugin.remasking.RemaskStepResult`.
@@ -104,7 +110,10 @@ def remask_after_block_forward(
         )
         raise ValueError(msg)
     assert_block_logits_shape(logits)
-    result = policy.apply(
+    pol: RemaskingPolicy = (
+        policy if policy is not None else Llada2DefaultRemaskingPolicy()
+    )
+    result = pol.apply(
         input_draft=input_draft,
         logits=logits,
         remasking_config=remasking_config,

--- a/vllm_dllm_plugin/remasking/handoff.py
+++ b/vllm_dllm_plugin/remasking/handoff.py
@@ -28,7 +28,6 @@ from vllm_dllm_plugin.remasking.base import (
     RemaskStepResult,
     validate_remask_step_result,
 )
-from vllm_dllm_plugin.remasking.llada2_default import Llada2DefaultRemaskingPolicy
 
 
 def assert_block_logits_shape(logits: Any) -> None:
@@ -69,8 +68,8 @@ def remask_after_block_forward(
     *,
     input_draft: Sequence[int],
     logits: Any,
+    policy: RemaskingPolicy,
     remasking_config: Mapping[str, Any] | None = None,
-    policy: RemaskingPolicy | None = None,
 ) -> RemaskStepResult:
     """Run one remasking step after a single-block forward (milestone issue #13).
 
@@ -84,11 +83,11 @@ def remask_after_block_forward(
         input_draft: This step's draft, length ``DRAFT_SIZE`` (aligned with
             ``scheduled_spec_decode_tokens``).
         logits: Non-``None`` block logits, 2-D ``(DRAFT_SIZE, vocab_size)``.
-        remasking_config: Optional knobs for the concrete policy.
-        policy: Optional :class:`~vllm_dllm_plugin.remasking.RemaskingPolicy`.
-            Defaults to
-            :class:`~vllm_dllm_plugin.remasking.Llada2DefaultRemaskingPolicy` for
-            the LLaDA2 MVP; pass another implementation for non-LLaDA2 stacks.
+        policy: Concrete :class:`~vllm_dllm_plugin.remasking.RemaskingPolicy`
+            (e.g. :class:`~vllm_dllm_plugin.remasking.Llada2DefaultRemaskingPolicy`
+            for the LLaDA2 MVP). Callers must supply this; there is no default
+            implementation in this helper.
+        remasking_config: Optional knobs forwarded to ``policy.apply``.
 
     Returns:
         Validated :class:`~vllm_dllm_plugin.remasking.RemaskStepResult`.
@@ -110,10 +109,7 @@ def remask_after_block_forward(
         )
         raise ValueError(msg)
     assert_block_logits_shape(logits)
-    pol: RemaskingPolicy = (
-        policy if policy is not None else Llada2DefaultRemaskingPolicy()
-    )
-    result = pol.apply(
+    result = policy.apply(
         input_draft=input_draft,
         logits=logits,
         remasking_config=remasking_config,


### PR DESCRIPTION
## Summary

Implements **[#13 — Connect model forward outputs to RemaskingPolicy inputs](https://github.com/vllm-project/dllm-plugin/issues/13)** for the mock-first MVP: **`vllm_dllm_plugin.remasking.handoff`** validates block logits and `input_draft`, calls **`RemaskingPolicy.apply`** with optional **`remasking_config`**, then **`validate_remask_step_result`**. Intended for **`DllmWorker` (#10)** after last-rank **`compute_logits`**, without **`GPUModelRunner`** forks.

## What’s included

| Area | Details |
|------|---------|
| **API** | `assert_block_logits_shape(logits)` — 2-D `(DRAFT_SIZE, vocab_size)` or length-`DRAFT_SIZE` nested rows; outer length only (per-row vocab width enforced by the policy, documented on the helper). `remask_after_block_forward(..., policy=..., remasking_config=...)` — **`policy` is required**. |
| **Package** | `remasking.__init__` exports `assert_block_logits_shape` and `remask_after_block_forward`. |
| **Docs** | `DESIGN_MVP.md` §5 (forward → remasking); `CONTRACTS.md` (forward handoff, `input_draft` table, §5–8 sync note); `MOCK_STACK_MODEL.md` (block logits vs handoff, `num_tokens == DRAFT_SIZE`); `mock_llada2.py` (call-site note for #10). |
| **Tests** | `tests/test_remask_forward_handoff.py` — guards, parity vs direct `Llada2DefaultRemaskingPolicy.apply`, stub policy proving `policy=` is used, `remasking_config` forwarding (`num_transfer`), tensor cases behind `importorskip("torch")`. |

## Out of scope

- **`DllmWorker` / scheduler** — [#10](https://github.com/vllm-project/dllm-plugin/issues/10) / [#8](https://github.com/vllm-project/dllm-plugin/issues/8).
- **Real weights / Phase 7** — [#12](https://github.com/vllm-project/dllm-plugin/issues/12).

## How to test

```bash
uv sync --group dev
uv run pytest -q
uv sync --group dev --extra vllm
uv run pytest -q tests/test_remask_forward_handoff.py
```

## Commits (high level)

Handoff module, exports, design/contract/mock docs, and handoff tests; refinements from review (required `policy`, stub policy test, `remasking_config` parity).

---

Closes https://github.com/vllm-project/dllm-plugin/issues/13
