### PR TITLE
feat: implement Phase 4 scheduler/worker runtime path (#8 #9 #10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ For MVP stack bring-up, enable the plugin by name and point vLLM at the plugin s
 ```bash
 export VLLM_PLUGINS=dllm
 vllm serve <model> \
-  --scheduler-cls vllm_dllm_plugin.scheduler:DllmScheduler \
-  --worker-cls vllm_dllm_plugin.worker:DllmWorker
+  --scheduler-cls vllm_dllm_plugin.runtime_scheduler:DllmRuntimeScheduler \
+  --worker-cls vllm_dllm_plugin.runtime_worker:DllmRuntimeWorker
 ```
 
-`DllmScheduler` and `DllmWorker` are available in the package and are designed around the field contract documented in [docs/CONTRACTS.md](docs/CONTRACTS.md). MVP expects `VLLM_USE_V2_MODEL_RUNNER=1`; grammar-constrained draft rewriting is intentionally rejected for dLLM block mode to avoid silent block-shape corruption. Block size is configured globally via `vllm_dllm_plugin.config.DRAFT_SIZE` (override with `VLLM_DLLM_DRAFT_SIZE` before importing the plugin) so scheduler/worker/remasking share one value. This remains Phase 4 helper-level runtime contract work, not full end-to-end serving integration. `register_dllm()` continues to register the **mock** model architectures when `vllm` imports successfully.
+`DllmRuntimeScheduler` and `DllmRuntimeWorker` are runtime adapter classes intended for CLI overrides. `DllmScheduler` and `DllmWorker` remain helper/contract implementations used by the adapters. MVP expects `VLLM_USE_V2_MODEL_RUNNER=1`; grammar-constrained draft rewriting is intentionally rejected for dLLM block mode to avoid silent block-shape corruption. Block size is configured globally via `vllm_dllm_plugin.config.DRAFT_SIZE` (override with `VLLM_DLLM_DRAFT_SIZE` before importing the plugin) so scheduler/worker/remasking share one value. This completes Phase 4 runtime wiring for mock bring-up, while Phase 6 integration confidence work remains separate. `register_dllm()` continues to register the **mock** model architectures when `vllm` imports successfully.
 
 ## Docs
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/vllm-project/dllm-plugin/actions/workflows/ci.yml/badge.svg)](https://github.com/vllm-project/dllm-plugin/actions/workflows/ci.yml)
 
-**vllm-dllm-plugin** is a [vLLM](https://github.com/vllm-project/vllm) plugin for **block-based diffusion language models (dLLMs)**. The package provides a `vllm.general_plugins` entry point (`dllm`), Phase 1 contracts (`config`, `remasking`), and a **mock registered model** for stack testing (Phases 2–6). Scheduler, worker, and production LLaDA2.0 logic are still in progress (see [docs/ROADMAP.md](docs/ROADMAP.md)).
+**vllm-dllm-plugin** is a [vLLM](https://github.com/vllm-project/vllm) plugin for **block-based diffusion language models (dLLMs)**. The package provides a `vllm.general_plugins` entry point (`dllm`), Phase 1 contracts (`config`, `remasking`), a **mock registered model** for stack testing (Phases 2–6), and Phase 4 scheduler/worker helpers that encode block scheduling, commit-0 rollback, draft handoff, and grammar-safety guardrails. Production LLaDA2.0 model logic remains in progress (see [docs/ROADMAP.md](docs/ROADMAP.md)).
 
 **Important:** `register_dllm()` first checks `importlib.util.find_spec("vllm")`; if `vllm` is not discoverable on `sys.path`, it returns without registering. If the spec exists but `from vllm import ModelRegistry` still fails, registration is skipped and a **DEBUG** traceback is logged. When that import succeeds, **`register_dllm()` registers two architecture names** with vLLM’s `ModelRegistry`, both targeting the **mock** in `vllm_dllm_plugin.models.mock_llada2` (not real inference—see [docs/MOCK_STACK_MODEL.md](docs/MOCK_STACK_MODEL.md)). Schedulers and workers are not registered yet.
 
@@ -38,7 +38,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for pre-commit, CI parity, and contributi
 
 ## Using the plugin (future)
 
-Once the MVP stack exists, you will enable the plugin by name and point vLLM at the plugin scheduler and worker classes (FQCNs will match the implemented modules), for example:
+For MVP stack bring-up, enable the plugin by name and point vLLM at the plugin scheduler and worker classes, for example:
 
 ```bash
 export VLLM_PLUGINS=dllm
@@ -47,7 +47,7 @@ vllm serve <model> \
   --worker-cls vllm_dllm_plugin.worker:DllmWorker
 ```
 
-Scheduler and worker classes are not implemented yet. **`register_dllm()`** already registers the **mock** model architectures when `vllm` imports successfully; end-to-end serving still needs the scheduler/worker stack from later milestones.
+`DllmScheduler` and `DllmWorker` are available in the package and are designed around the field contract documented in [docs/CONTRACTS.md](docs/CONTRACTS.md). MVP expects `VLLM_USE_V2_MODEL_RUNNER=1`; grammar-constrained draft rewriting is intentionally rejected for dLLM block mode to avoid silent block-shape corruption. `register_dllm()` continues to register the **mock** model architectures when `vllm` imports successfully.
 
 ## Docs
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ vllm serve <model> \
   --worker-cls vllm_dllm_plugin.worker:DllmWorker
 ```
 
-`DllmScheduler` and `DllmWorker` are available in the package and are designed around the field contract documented in [docs/CONTRACTS.md](docs/CONTRACTS.md). MVP expects `VLLM_USE_V2_MODEL_RUNNER=1`; grammar-constrained draft rewriting is intentionally rejected for dLLM block mode to avoid silent block-shape corruption. `register_dllm()` continues to register the **mock** model architectures when `vllm` imports successfully.
+`DllmScheduler` and `DllmWorker` are available in the package and are designed around the field contract documented in [docs/CONTRACTS.md](docs/CONTRACTS.md). MVP expects `VLLM_USE_V2_MODEL_RUNNER=1`; grammar-constrained draft rewriting is intentionally rejected for dLLM block mode to avoid silent block-shape corruption. Block size is configured globally via `vllm_dllm_plugin.config.DRAFT_SIZE` (override with `VLLM_DLLM_DRAFT_SIZE` before importing the plugin) so scheduler/worker/remasking share one value. This remains Phase 4 helper-level runtime contract work, not full end-to-end serving integration. `register_dllm()` continues to register the **mock** model architectures when `vllm` imports successfully.
 
 ## Docs
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,6 +4,10 @@
 
 from __future__ import annotations
 
+import importlib
+
+import pytest
+
 from vllm_dllm_plugin import config
 
 
@@ -17,6 +21,9 @@ def test_model_and_flag_constants_are_non_empty() -> None:
     assert isinstance(config.DLLM_STRICT_STACK_VALIDATION_DEFAULT, bool)
 
 
-def test_llada2_default_remasking_defaults() -> None:
-    assert isinstance(config.LLADA2_DEFAULT_MASK_TOKEN_ID, int)
-    assert isinstance(config.LLADA2_DEFAULT_COMMIT_CONFIDENCE_THRESHOLD, float)
+def test_draft_size_can_be_configured_via_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(config.DLLM_DRAFT_SIZE_ENV_VAR, "48")
+    reloaded = importlib.reload(config)
+    assert reloaded.DRAFT_SIZE == 48
+    monkeypatch.delenv(config.DLLM_DRAFT_SIZE_ENV_VAR, raising=False)
+    importlib.reload(config)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,6 +19,10 @@ def test_model_and_flag_constants_are_non_empty() -> None:
     assert config.LLADA2_ARCHITECTURE_NAME
     assert config.DLLM_MOCK_STACK_MODEL_ID
     assert isinstance(config.DLLM_STRICT_STACK_VALIDATION_DEFAULT, bool)
+    assert isinstance(config.LLADA2_DEFAULT_MASK_TOKEN_ID, int)
+    assert config.LLADA2_DEFAULT_MASK_TOKEN_ID >= 0
+    assert isinstance(config.LLADA2_DEFAULT_COMMIT_CONFIDENCE_THRESHOLD, float)
+    assert 0.0 < config.LLADA2_DEFAULT_COMMIT_CONFIDENCE_THRESHOLD < 1.0
 
 
 def test_draft_size_can_be_configured_via_env(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -33,7 +33,17 @@ def test_register_dllm_does_not_raise() -> None:
     vllm_dllm_plugin.register_dllm()
 
 
-@pytest.mark.parametrize("attr", ("register_dllm", "__version__"))
+@pytest.mark.parametrize(
+    "attr",
+    (
+        "register_dllm",
+        "__version__",
+        "DllmScheduler",
+        "DllmWorker",
+        "DllmRuntimeScheduler",
+        "DllmRuntimeWorker",
+    ),
+)
 def test_public_api(attr: str) -> None:
     assert hasattr(vllm_dllm_plugin, attr)
 

--- a/tests/test_remask_forward_handoff.py
+++ b/tests/test_remask_forward_handoff.py
@@ -87,7 +87,7 @@ def test_remask_rejects_logits_none(
 
 def test_assert_block_logits_shape_rejects_wrong_len_sequence() -> None:
     short = [_mock_stub_row() for _ in range(DRAFT_SIZE - 1)]
-    with pytest.raises(ValueError, match="DRAFT_SIZE"):
+    with pytest.raises(ValueError, match="draft_size"):
         assert_block_logits_shape(short)
 
 
@@ -179,7 +179,7 @@ def test_remask_rejects_wrong_tensor_first_dim(
 ) -> None:
     torch = pytest.importorskip("torch")
     bad = torch.zeros(DRAFT_SIZE + 1, 128)
-    with pytest.raises(ValueError, match="DRAFT_SIZE"):
+    with pytest.raises(ValueError, match="draft_size"):
         remask_after_block_forward(
             input_draft=_draft_all_mask(),
             logits=bad,

--- a/tests/test_runtime_adapters.py
+++ b/tests/test_runtime_adapters.py
@@ -94,3 +94,45 @@ def test_runtime_scheduler_contract_rejects_missing_output_coverage() -> None:
             expected_req_ids=("r1", "r2"),
             model_runner_output=fake_out,
         )
+
+
+def test_runtime_worker_contract_rejects_missing_input_draft() -> None:
+    from vllm_dllm_plugin.runtime_worker import validate_runtime_input_draft
+
+    with pytest.raises(ValueError, match="missing scheduled_spec_decode_tokens"):
+        validate_runtime_input_draft(
+            request_id="r1",
+            input_draft=None,
+            draft_size=DRAFT_SIZE,
+        )
+
+
+def test_runtime_worker_contract_rejects_malformed_input_draft_length() -> None:
+    from vllm_dllm_plugin.runtime_worker import validate_runtime_input_draft
+
+    with pytest.raises(ValueError, match="malformed scheduled_spec_decode_tokens"):
+        validate_runtime_input_draft(
+            request_id="r1",
+            input_draft=[1, 2, 3],
+            draft_size=DRAFT_SIZE,
+        )
+
+
+def test_runtime_worker_contract_rejects_missing_draft_handoff_coverage() -> None:
+    from vllm_dllm_plugin.runtime_worker import validate_runtime_draft_handoff_coverage
+
+    with pytest.raises(ValueError, match="missing request_id"):
+        validate_runtime_draft_handoff_coverage(
+            expected_req_ids={"r1", "r2"},
+            produced_req_ids=["r1"],
+        )
+
+
+def test_runtime_worker_contract_rejects_duplicate_draft_handoff_coverage() -> None:
+    from vllm_dllm_plugin.runtime_worker import validate_runtime_draft_handoff_coverage
+
+    with pytest.raises(ValueError, match="duplicate request_id"):
+        validate_runtime_draft_handoff_coverage(
+            expected_req_ids={"r1"},
+            produced_req_ids=["r1", "r1"],
+        )

--- a/tests/test_runtime_adapters.py
+++ b/tests/test_runtime_adapters.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for vLLM-facing runtime adapter classes."""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+def test_runtime_adapter_fqcn_targets_resolve() -> None:
+    mod_sched = importlib.import_module("vllm_dllm_plugin.runtime_scheduler")
+    mod_worker = importlib.import_module("vllm_dllm_plugin.runtime_worker")
+    assert hasattr(mod_sched, "DllmRuntimeScheduler")
+    assert hasattr(mod_worker, "DllmRuntimeWorker")
+
+
+def test_runtime_scheduler_behavior_depends_on_vllm_availability() -> None:
+    from vllm_dllm_plugin.runtime_scheduler import (
+        _VLLM_AVAILABLE,
+        DllmRuntimeScheduler,
+    )
+
+    if not _VLLM_AVAILABLE:
+        with pytest.raises(RuntimeError, match="requires vLLM"):
+            DllmRuntimeScheduler()
+    else:
+        from vllm.v1.core.sched.scheduler import Scheduler
+
+        assert issubclass(DllmRuntimeScheduler, Scheduler)
+
+
+def test_runtime_worker_behavior_depends_on_vllm_availability() -> None:
+    from vllm_dllm_plugin.runtime_worker import (
+        _VLLM_AVAILABLE,
+        DllmRuntimeWorker,
+    )
+
+    if not _VLLM_AVAILABLE:
+        with pytest.raises(RuntimeError, match="requires vLLM"):
+            DllmRuntimeWorker()
+    else:
+        from vllm.v1.worker.gpu_worker import Worker
+
+        assert issubclass(DllmRuntimeWorker, Worker)

--- a/tests/test_runtime_adapters.py
+++ b/tests/test_runtime_adapters.py
@@ -8,6 +8,10 @@ import importlib
 
 import pytest
 
+from vllm_dllm_plugin.config import DRAFT_SIZE, LLADA2_DEFAULT_MASK_TOKEN_ID
+from vllm_dllm_plugin.scheduler import DllmScheduler
+from vllm_dllm_plugin.worker import DllmWorker
+
 
 def test_runtime_adapter_fqcn_targets_resolve() -> None:
     mod_sched = importlib.import_module("vllm_dllm_plugin.runtime_scheduler")
@@ -44,3 +48,49 @@ def test_runtime_worker_behavior_depends_on_vllm_availability() -> None:
         from vllm.v1.worker.gpu_worker import Worker
 
         assert issubclass(DllmRuntimeWorker, Worker)
+
+
+class _FakeModelRunnerOutput:
+    def __init__(self, req_ids: list[str], sampled_token_ids: list[list[int]]) -> None:
+        self.req_ids = req_ids
+        self.sampled_token_ids = sampled_token_ids
+
+
+def test_runtime_contract_progress_with_default_policy() -> None:
+    from vllm_dllm_plugin.runtime_scheduler import validate_scheduler_worker_contract
+    from vllm_dllm_plugin.runtime_worker import run_block_contract_from_model_output
+
+    worker_helper = DllmWorker(require_v2_model_runner=False)
+    scheduler_helper = DllmScheduler()
+    input_draft = [LLADA2_DEFAULT_MASK_TOKEN_ID] * DRAFT_SIZE
+
+    step = run_block_contract_from_model_output(
+        helper=worker_helper,
+        request_id="r1",
+        input_draft=input_draft,
+        sampled_token_ids=[],
+    )
+    assert len(step.sampled_token_ids) > 0
+    assert len(step.next_input_block) == DRAFT_SIZE
+
+    fake_out = _FakeModelRunnerOutput(
+        req_ids=["r1"],
+        sampled_token_ids=[list(step.sampled_token_ids)],
+    )
+    validate_scheduler_worker_contract(
+        helper=scheduler_helper,
+        expected_req_ids=("r1",),
+        model_runner_output=fake_out,
+    )
+
+
+def test_runtime_scheduler_contract_rejects_missing_output_coverage() -> None:
+    from vllm_dllm_plugin.runtime_scheduler import validate_scheduler_worker_contract
+
+    fake_out = _FakeModelRunnerOutput(req_ids=["r1"], sampled_token_ids=[[]])
+    with pytest.raises(ValueError, match="missing worker results"):
+        validate_scheduler_worker_contract(
+            helper=DllmScheduler(),
+            expected_req_ids=("r1", "r2"),
+            model_runner_output=fake_out,
+        )

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -100,6 +100,19 @@ def test_update_from_output_rejects_unknown_request_id() -> None:
         )
 
 
+def test_update_from_output_rejects_missing_worker_result() -> None:
+    sched = DllmScheduler()
+    state1 = DllmRequestState(request_id="r1")
+    state2 = DllmRequestState(request_id="r2")
+    sched.schedule_decode_step(requests=((state1, ()), (state2, ())))
+
+    with pytest.raises(ValueError, match="missing worker results"):
+        sched.update_from_output(
+            states={"r1": state1, "r2": state2},
+            worker_results=(DllmWorkerResult(request_id="r1", sampled_token_ids=(1,)),),
+        )
+
+
 def test_update_from_output_rejects_duplicate_request_ids() -> None:
     sched = DllmScheduler()
     state = DllmRequestState(request_id="r1")

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Phase 4 scheduler tests (issues #8 and #9)."""
+
+from __future__ import annotations
+
+import pytest
+
+from vllm_dllm_plugin.config import DRAFT_SIZE, LLADA2_DEFAULT_MASK_TOKEN_ID
+from vllm_dllm_plugin.scheduler import (
+    DllmRequestState,
+    DllmScheduler,
+    DllmWorkerResult,
+)
+
+
+def test_initialize_first_block_pads_with_mask() -> None:
+    sched = DllmScheduler()
+    block = sched.initialize_first_block(prompt_token_ids=(10, 11, 12))
+    assert len(block) == DRAFT_SIZE
+    assert block[:3] == (10, 11, 12)
+    assert block[3:] == (LLADA2_DEFAULT_MASK_TOKEN_ID,) * (DRAFT_SIZE - 3)
+
+
+def test_schedule_decode_step_initializes_spec_tokens_and_counts() -> None:
+    sched = DllmScheduler()
+    state = DllmRequestState(request_id="r1")
+
+    out = sched.schedule_decode_step(requests=((state, (7, 8)),))
+
+    assert len(out.requests) == 1
+    req = out.requests[0]
+    assert req.request_id == "r1"
+    assert req.num_scheduled_tokens == DRAFT_SIZE
+    assert len(req.scheduled_spec_decode_tokens) == DRAFT_SIZE
+    assert state.spec_token_ids == req.scheduled_spec_decode_tokens
+    assert state.num_computed_tokens == DRAFT_SIZE
+
+
+def test_update_from_output_rolls_back_on_empty_commit() -> None:
+    sched = DllmScheduler()
+    state = DllmRequestState(request_id="r1")
+    sched.schedule_decode_step(requests=((state, ()),))
+    assert state.num_computed_tokens == DRAFT_SIZE
+
+    sched.update_from_output(
+        states={"r1": state},
+        worker_results=(DllmWorkerResult(request_id="r1", sampled_token_ids=()),),
+    )
+    assert state.num_computed_tokens == 0
+
+
+def test_update_from_output_keeps_count_when_tokens_committed() -> None:
+    sched = DllmScheduler()
+    state = DllmRequestState(request_id="r1")
+    sched.schedule_decode_step(requests=((state, ()),))
+    assert state.num_computed_tokens == DRAFT_SIZE
+
+    sched.update_from_output(
+        states={"r1": state},
+        worker_results=(DllmWorkerResult(request_id="r1", sampled_token_ids=(1,)),),
+    )
+    assert state.num_computed_tokens == DRAFT_SIZE
+
+
+def test_update_draft_token_ids_rejects_grammar_constrained_path() -> None:
+    sched = DllmScheduler()
+    state = DllmRequestState(request_id="r1")
+
+    with pytest.raises(ValueError, match="incompatible with AR draft grammar"):
+        sched.update_draft_token_ids(
+            state=state,
+            next_input_block=(0,) * DRAFT_SIZE,
+            grammar_constrained=True,
+        )
+
+
+def test_update_draft_token_ids_in_output_rejects_grammar_constrained_path() -> None:
+    sched = DllmScheduler()
+    state = DllmRequestState(request_id="r1")
+    output = sched.schedule_decode_step(requests=((state, (1, 2, 3)),))
+
+    with pytest.raises(ValueError, match="incompatible with AR draft grammar"):
+        sched.update_draft_token_ids_in_output(
+            output=output,
+            next_blocks_by_request_id={"r1": (9,) * DRAFT_SIZE},
+            grammar_constrained=True,
+        )

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -63,6 +63,20 @@ def test_update_from_output_keeps_count_when_tokens_committed() -> None:
     assert state.num_computed_tokens == DRAFT_SIZE
 
 
+def test_update_from_output_rejects_unknown_request_id() -> None:
+    sched = DllmScheduler()
+    state = DllmRequestState(request_id="known")
+    sched.schedule_decode_step(requests=((state, ()),))
+
+    with pytest.raises(ValueError, match="unknown request_id"):
+        sched.update_from_output(
+            states={"known": state},
+            worker_results=(
+                DllmWorkerResult(request_id="other", sampled_token_ids=()),
+            ),
+        )
+
+
 def test_update_draft_token_ids_rejects_grammar_constrained_path() -> None:
     sched = DllmScheduler()
     state = DllmRequestState(request_id="r1")

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -50,7 +50,7 @@ def test_update_from_output_rolls_back_on_empty_commit() -> None:
     assert state.num_computed_tokens == 0
 
 
-def test_update_from_output_keeps_count_when_tokens_committed() -> None:
+def test_update_from_output_counts_only_committed_tokens() -> None:
     sched = DllmScheduler()
     state = DllmRequestState(request_id="r1")
     sched.schedule_decode_step(requests=((state, ()),))
@@ -60,7 +60,30 @@ def test_update_from_output_keeps_count_when_tokens_committed() -> None:
         states={"r1": state},
         worker_results=(DllmWorkerResult(request_id="r1", sampled_token_ids=(1,)),),
     )
-    assert state.num_computed_tokens == DRAFT_SIZE
+    assert state.num_computed_tokens == 1
+
+
+def test_update_from_output_multi_step_partial_commits_accumulate_correctly() -> None:
+    sched = DllmScheduler()
+    state = DllmRequestState(request_id="r1")
+
+    sched.schedule_decode_step(requests=((state, ()),))
+    sched.update_from_output(
+        states={"r1": state},
+        worker_results=(
+            DllmWorkerResult(request_id="r1", sampled_token_ids=(1, 2, 3, 4, 5)),
+        ),
+    )
+    assert state.num_computed_tokens == 5
+
+    sched.schedule_decode_step(requests=((state, ()),))
+    sched.update_from_output(
+        states={"r1": state},
+        worker_results=(
+            DllmWorkerResult(request_id="r1", sampled_token_ids=(9, 10, 11)),
+        ),
+    )
+    assert state.num_computed_tokens == 8
 
 
 def test_update_from_output_rejects_unknown_request_id() -> None:
@@ -73,6 +96,21 @@ def test_update_from_output_rejects_unknown_request_id() -> None:
             states={"known": state},
             worker_results=(
                 DllmWorkerResult(request_id="other", sampled_token_ids=()),
+            ),
+        )
+
+
+def test_update_from_output_rejects_duplicate_request_ids() -> None:
+    sched = DllmScheduler()
+    state = DllmRequestState(request_id="r1")
+    sched.schedule_decode_step(requests=((state, ()),))
+
+    with pytest.raises(ValueError, match="duplicate request_id"):
+        sched.update_from_output(
+            states={"r1": state},
+            worker_results=(
+                DllmWorkerResult(request_id="r1", sampled_token_ids=(1,)),
+                DllmWorkerResult(request_id="r1", sampled_token_ids=(2,)),
             ),
         )
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -4,10 +4,13 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
+from typing import Any
+
 import pytest
 
 from vllm_dllm_plugin.config import DRAFT_SIZE, LLADA2_DEFAULT_MASK_TOKEN_ID
-from vllm_dllm_plugin.remasking import Llada2DefaultRemaskingPolicy
+from vllm_dllm_plugin.remasking import Llada2DefaultRemaskingPolicy, RemaskStepResult
 from vllm_dllm_plugin.worker import (
     DllmWorker,
     is_v2_model_runner_enabled,
@@ -25,6 +28,25 @@ def _mock_logits(*, vocab_size: int = 128) -> list[list[float]]:
         row[0] = 1.0
         rows.append(row)
     return rows
+
+
+class _BadBlockPolicy:
+    """Returns an invalid next block length for contract-boundary testing."""
+
+    __test__ = False
+
+    def apply(
+        self,
+        *,
+        input_draft: Sequence[int],
+        logits: Any | None = None,
+        remasking_config: Mapping[str, Any] | None = None,
+    ) -> RemaskStepResult:
+        del input_draft, logits, remasking_config
+        return RemaskStepResult(
+            committed_token_ids=(),
+            next_input_block=(LLADA2_DEFAULT_MASK_TOKEN_ID,),
+        )
 
 
 def test_v2_model_runner_flag_detection(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -66,3 +88,18 @@ def test_worker_one_block_flow_maps_to_scheduler_contract(
     sched_result = worker.as_scheduler_result(step)
     assert sched_result.request_id == "r1"
     assert sched_result.sampled_token_ids == step.sampled_token_ids
+
+
+def test_worker_rejects_malformed_policy_next_input_block(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VLLM_USE_V2_MODEL_RUNNER", "1")
+    worker = DllmWorker(require_v2_model_runner=True)
+
+    with pytest.raises(ValueError, match="next_input_block"):
+        worker.run_one_block(
+            request_id="r1",
+            input_draft=_draft_all_mask(),
+            logits=_mock_logits(),
+            policy=_BadBlockPolicy(),
+        )

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Phase 4 worker tests (issue #10)."""
+
+from __future__ import annotations
+
+import pytest
+
+from vllm_dllm_plugin.config import DRAFT_SIZE, LLADA2_DEFAULT_MASK_TOKEN_ID
+from vllm_dllm_plugin.remasking import Llada2DefaultRemaskingPolicy
+from vllm_dllm_plugin.worker import (
+    DllmWorker,
+    is_v2_model_runner_enabled,
+)
+
+
+def _draft_all_mask() -> tuple[int, ...]:
+    return (LLADA2_DEFAULT_MASK_TOKEN_ID,) * DRAFT_SIZE
+
+
+def _mock_logits(*, vocab_size: int = 128) -> list[list[float]]:
+    rows: list[list[float]] = []
+    for _ in range(DRAFT_SIZE):
+        row = [0.0] * vocab_size
+        row[0] = 1.0
+        rows.append(row)
+    return rows
+
+
+def test_v2_model_runner_flag_detection(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("VLLM_USE_V2_MODEL_RUNNER", "1")
+    assert is_v2_model_runner_enabled()
+    monkeypatch.setenv("VLLM_USE_V2_MODEL_RUNNER", "false")
+    assert not is_v2_model_runner_enabled()
+
+
+def test_worker_requires_v2_when_requested(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("VLLM_USE_V2_MODEL_RUNNER", raising=False)
+    with pytest.raises(RuntimeError, match="VLLM_USE_V2_MODEL_RUNNER=1"):
+        DllmWorker(require_v2_model_runner=True)
+
+
+def test_worker_one_block_flow_maps_to_scheduler_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VLLM_USE_V2_MODEL_RUNNER", "1")
+    worker = DllmWorker(require_v2_model_runner=True)
+    policy = Llada2DefaultRemaskingPolicy()
+
+    step = worker.run_one_block(
+        request_id="r1",
+        input_draft=_draft_all_mask(),
+        logits=_mock_logits(),
+        policy=policy,
+        remasking_config={"num_transfer": DRAFT_SIZE},
+    )
+
+    assert step.request_id == "r1"
+    assert len(step.sampled_token_ids) == DRAFT_SIZE
+    assert len(step.next_input_block) == DRAFT_SIZE
+    assert step.next_input_block == (LLADA2_DEFAULT_MASK_TOKEN_ID,) * DRAFT_SIZE
+    assert worker.take_draft_token_ids(step) == step.next_input_block
+
+    sched_result = worker.as_scheduler_result(step)
+    assert sched_result.request_id == "r1"
+    assert sched_result.sampled_token_ids == step.sampled_token_ids

--- a/vllm_dllm_plugin/__init__.py
+++ b/vllm_dllm_plugin/__init__.py
@@ -9,6 +9,8 @@ import logging
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
+from vllm_dllm_plugin.runtime_scheduler import DllmRuntimeScheduler
+from vllm_dllm_plugin.runtime_worker import DllmRuntimeWorker
 from vllm_dllm_plugin.scheduler import DllmScheduler
 from vllm_dllm_plugin.worker import DllmWorker
 
@@ -83,6 +85,8 @@ def register_dllm() -> None:
 
 
 __all__ = [
+    "DllmRuntimeScheduler",
+    "DllmRuntimeWorker",
     "DllmScheduler",
     "DllmWorker",
     "__version__",

--- a/vllm_dllm_plugin/__init__.py
+++ b/vllm_dllm_plugin/__init__.py
@@ -9,6 +9,9 @@ import logging
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
+from vllm_dllm_plugin.scheduler import DllmScheduler
+from vllm_dllm_plugin.worker import DllmWorker
+
 try:
     __version__ = version("vllm-dllm-plugin")
 except PackageNotFoundError:
@@ -77,3 +80,11 @@ def register_dllm() -> None:
             arch,
             DLLM_MOCK_MODEL_CLASS_FQCN,
         )
+
+
+__all__ = [
+    "DllmScheduler",
+    "DllmWorker",
+    "__version__",
+    "register_dllm",
+]

--- a/vllm_dllm_plugin/config.py
+++ b/vllm_dllm_plugin/config.py
@@ -8,11 +8,32 @@ remasking, and tests share one source of truth (see ``docs/DESIGN_MVP.md``).
 
 from __future__ import annotations
 
+import os
 from typing import Final
 
+#: Environment variable controlling global dLLM block size for the plugin stack.
+DLLM_DRAFT_SIZE_ENV_VAR: Final[str] = "VLLM_DLLM_DRAFT_SIZE"
+
+
+def _read_draft_size() -> int:
+    raw = os.environ.get(DLLM_DRAFT_SIZE_ENV_VAR)
+    if raw is None:
+        return 32
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise ValueError(
+            f"{DLLM_DRAFT_SIZE_ENV_VAR} must be an integer, got {raw!r}",
+        ) from exc
+    if value <= 0:
+        raise ValueError(f"{DLLM_DRAFT_SIZE_ENV_VAR} must be positive, got {value}")
+    return value
+
+
 #: Fixed diffusion / spec-decode **block size** for one plugin step (tokens).
-#: LLaDA2.0 MVP uses 32 per ``docs/DESIGN_MVP.md`` (Goals table, section 1).
-DRAFT_SIZE: Final[int] = 32
+#: Defaults to 32 for LLaDA2.0 MVP and can be overridden via
+#: ``VLLM_DLLM_DRAFT_SIZE`` so scheduler/worker/remasking share one value.
+DRAFT_SIZE: Final[int] = _read_draft_size()
 
 #: Primary registered architecture key for the real LLaDA2.0 vLLM model module
 #: (HF mapping). Until Phase 7 (#12), registration points at the **mock** class
@@ -40,8 +61,8 @@ DLLM_STRICT_STACK_VALIDATION_DEFAULT: Final[bool] = True
 LLADA2_DEFAULT_MASK_TOKEN_ID: Final[int] = 1
 
 #: Default number of denoise steps used to build the per-step **transfer count**
-#: schedule (``block_len // steps`` layout). Matches ``DRAFT_SIZE`` for one transfer
-#: per step when the schedule is not overridden.
+#: schedule (``block_len // steps`` layout). Matches configured ``DRAFT_SIZE`` for
+#: one transfer per step when the schedule is not overridden.
 LLADA2_DEFAULT_DENOISE_STEPS: Final[int] = DRAFT_SIZE
 
 #: Default minimum softmax probability on the per-position argmax token required to

--- a/vllm_dllm_plugin/remasking/base.py
+++ b/vllm_dllm_plugin/remasking/base.py
@@ -4,7 +4,7 @@
 
 Invariants align with ``docs/DESIGN_MVP.md`` section 8 (remasking composability)
 and use :data:`~vllm_dllm_plugin.config.DRAFT_SIZE` for next-block length.
-Concrete policies live in separate modules (e.g. ``llada2_default`` for LLaDA2.0).
+Concrete policies (e.g. LLaDA2.0 default) live in separate modules (issue #7).
 """
 
 from __future__ import annotations
@@ -46,7 +46,7 @@ class RemaskingPolicy(Protocol):
 
     **MVP contract (conceptual, section 8):**
 
-    - **Input:** current input draft, logits or equivalent scores, optional
+    - **Input:** current input block, logits or equivalent scores, optional
       policy knobs (threshold, top-k, etc.).
     - **Output:** committed ids (subset of positions), next input block of length
       ``DRAFT_SIZE``, and (in concrete implementations) internal mask/draft
@@ -72,7 +72,7 @@ class RemaskingPolicy(Protocol):
         """Run one remasking step for the current block.
 
         Args:
-            input_draft: This step's **input draft** (length typically
+            input_draft: This step's **input block** (length typically
                 ``DRAFT_SIZE`` for decode), aligned with
                 ``SchedulerOutput.scheduled_spec_decode_tokens``
                 (``DESIGN_MVP`` section 7).
@@ -90,8 +90,12 @@ class RemaskingPolicy(Protocol):
         ...
 
 
-def validate_remask_step_result(result: RemaskStepResult) -> None:
-    """Assert MVP shape constraints using module-level ``DRAFT_SIZE``.
+def validate_remask_step_result(
+    result: RemaskStepResult,
+    *,
+    draft_size: int = DRAFT_SIZE,
+) -> None:
+    """Assert MVP shape constraints against ``draft_size``.
 
     Compare :data:`~vllm_dllm_plugin.config.DRAFT_SIZE`. For per-model or
     per-request block sizes, this helper would need an explicit length argument or
@@ -99,15 +103,17 @@ def validate_remask_step_result(result: RemaskStepResult) -> None:
     ``config.DRAFT_SIZE`` would be incorrect (MVP assumes one global draft size).
     """
 
-    if len(result.next_input_block) != DRAFT_SIZE:
+    if draft_size <= 0:
+        raise ValueError(f"draft_size must be positive, got {draft_size}")
+    if len(result.next_input_block) != draft_size:
         msg = (
-            f"next_input_block must have length DRAFT_SIZE={DRAFT_SIZE}, "
+            f"next_input_block must have length draft_size={draft_size}, "
             f"got {len(result.next_input_block)}"
         )
         raise ValueError(msg)
-    if not 0 <= len(result.committed_token_ids) <= DRAFT_SIZE:
+    if not 0 <= len(result.committed_token_ids) <= draft_size:
         msg = (
             "committed_token_ids length must be in "
-            f"0..DRAFT_SIZE (inclusive), got {len(result.committed_token_ids)}"
+            f"0..draft_size (inclusive), got {len(result.committed_token_ids)}"
         )
         raise ValueError(msg)

--- a/vllm_dllm_plugin/remasking/handoff.py
+++ b/vllm_dllm_plugin/remasking/handoff.py
@@ -30,10 +30,10 @@ from vllm_dllm_plugin.remasking.base import (
 )
 
 
-def assert_block_logits_shape(logits: Any) -> None:
-    """Require 2-D block logits with first dimension ``DRAFT_SIZE``.
+def assert_block_logits_shape(logits: Any, *, draft_size: int = DRAFT_SIZE) -> None:
+    """Require 2-D block logits with first dimension ``draft_size``.
 
-    Accepts ``torch.Tensor`` (via ``shape``) or a length-``DRAFT_SIZE`` sequence
+    Accepts ``torch.Tensor`` (via ``shape``) or a length-``draft_size`` sequence
     of per-position rows without importing ``torch``.
 
     For nested sequences, only the **outer** length is checked here; consistent
@@ -54,13 +54,13 @@ def assert_block_logits_shape(logits: Any) -> None:
             )
             raise ValueError(msg)
         n0 = int(shape[0])
-        if n0 != DRAFT_SIZE:
-            msg = f"logits first dimension must be DRAFT_SIZE={DRAFT_SIZE}, got {n0}"
+        if n0 != draft_size:
+            msg = f"logits first dimension must be draft_size={draft_size}, got {n0}"
             raise ValueError(msg)
         return
     n_pos = len(logits)
-    if n_pos != DRAFT_SIZE:
-        msg = f"logits first dimension must be DRAFT_SIZE={DRAFT_SIZE}, got {n_pos}"
+    if n_pos != draft_size:
+        msg = f"logits first dimension must be draft_size={draft_size}, got {n_pos}"
         raise ValueError(msg)
 
 
@@ -70,6 +70,7 @@ def remask_after_block_forward(
     logits: Any,
     policy: RemaskingPolicy,
     remasking_config: Mapping[str, Any] | None = None,
+    draft_size: int = DRAFT_SIZE,
 ) -> RemaskStepResult:
     """Run one remasking step after a single-block forward (milestone issue #13).
 
@@ -80,9 +81,9 @@ def remask_after_block_forward(
     (``docs/DESIGN_MVP.md`` §6–7).
 
     Args:
-        input_draft: This step's draft, length ``DRAFT_SIZE`` (aligned with
+        input_draft: This step's draft, length ``draft_size`` (aligned with
             ``scheduled_spec_decode_tokens``).
-        logits: Non-``None`` block logits, 2-D ``(DRAFT_SIZE, vocab_size)``.
+        logits: Non-``None`` block logits, 2-D ``(draft_size, vocab_size)``.
         policy: Concrete :class:`~vllm_dllm_plugin.remasking.RemaskingPolicy`
             (e.g. :class:`~vllm_dllm_plugin.remasking.Llada2DefaultRemaskingPolicy`
             for the LLaDA2 MVP). Callers must supply this; there is no default
@@ -96,9 +97,11 @@ def remask_after_block_forward(
         ValueError: If ``input_draft`` length is wrong, ``logits`` is ``None``,
             or logits fail :func:`assert_block_logits_shape`.
     """
-    if len(input_draft) != DRAFT_SIZE:
+    if draft_size <= 0:
+        raise ValueError(f"draft_size must be positive, got {draft_size}")
+    if len(input_draft) != draft_size:
         msg = (
-            f"input_draft length must be DRAFT_SIZE={DRAFT_SIZE}, "
+            f"input_draft length must be draft_size={draft_size}, "
             f"got {len(input_draft)}"
         )
         raise ValueError(msg)
@@ -108,13 +111,13 @@ def remask_after_block_forward(
             "rank where compute_logits returns a tensor (see docs/MOCK_STACK_MODEL.md)."
         )
         raise ValueError(msg)
-    assert_block_logits_shape(logits)
+    assert_block_logits_shape(logits, draft_size=draft_size)
     result = policy.apply(
         input_draft=input_draft,
         logits=logits,
         remasking_config=remasking_config,
     )
-    validate_remask_step_result(result)
+    validate_remask_step_result(result, draft_size=draft_size)
     return result
 
 

--- a/vllm_dllm_plugin/runtime_scheduler.py
+++ b/vllm_dllm_plugin/runtime_scheduler.py
@@ -25,10 +25,40 @@ try:
 
     _VLLM_AVAILABLE = True
 except ImportError:  # pragma: no cover - exercised only in no-vLLM envs.
-    VllmScheduler = object  # type: ignore[assignment,misc]
-    DraftTokenIds = Any  # type: ignore[assignment]
-    ModelRunnerOutput = Any  # type: ignore[assignment]
+    VllmScheduler = object
+    DraftTokenIds = Any
+    ModelRunnerOutput = Any
     _VLLM_AVAILABLE = False
+
+
+def validate_scheduler_worker_contract(
+    *,
+    helper: DllmSchedulerHelper,
+    expected_req_ids: tuple[str, ...],
+    model_runner_output: Any,
+) -> None:
+    """Apply helper-level scheduler output validation to runtime outputs."""
+
+    helper_states = {
+        req_id: DllmRequestState(
+            request_id=req_id,
+            # Use draft_size so helper accounting checks can run.
+            num_computed_tokens=helper.draft_size,
+        )
+        for req_id in expected_req_ids
+    }
+    helper_results = tuple(
+        DllmWorkerResult(
+            request_id=req_id,
+            sampled_token_ids=tuple(sampled_token_ids),
+        )
+        for req_id, sampled_token_ids in zip(
+            model_runner_output.req_ids,
+            model_runner_output.sampled_token_ids,
+            strict=True,
+        )
+    )
+    helper.update_from_output(states=helper_states, worker_results=helper_results)
 
 
 class DllmRuntimeScheduler(VllmScheduler):
@@ -76,29 +106,10 @@ class DllmRuntimeScheduler(VllmScheduler):
     ) -> dict[int, Any]:
         """Validate dLLM scheduler-worker contract before delegating upstream."""
 
-        expected_req_ids = tuple(scheduler_output.num_scheduled_tokens.keys())
-        helper_states = {
-            req_id: DllmRequestState(
-                request_id=req_id,
-                # Use draft_size so helper accounting checks can run.
-                num_computed_tokens=self._dllm_helper.draft_size,
-            )
-            for req_id in expected_req_ids
-        }
-        helper_results = tuple(
-            DllmWorkerResult(
-                request_id=req_id,
-                sampled_token_ids=tuple(sampled_token_ids),
-            )
-            for req_id, sampled_token_ids in zip(
-                model_runner_output.req_ids,
-                model_runner_output.sampled_token_ids,
-                strict=True,
-            )
-        )
-        self._dllm_helper.update_from_output(
-            states=helper_states,
-            worker_results=helper_results,
+        validate_scheduler_worker_contract(
+            helper=self._dllm_helper,
+            expected_req_ids=tuple(scheduler_output.num_scheduled_tokens.keys()),
+            model_runner_output=model_runner_output,
         )
         return super().update_from_output(scheduler_output, model_runner_output)
 
@@ -127,4 +138,4 @@ class DllmRuntimeScheduler(VllmScheduler):
                 )
 
 
-__all__ = ["DllmRuntimeScheduler"]
+__all__ = ["DllmRuntimeScheduler", "validate_scheduler_worker_contract"]

--- a/vllm_dllm_plugin/runtime_scheduler.py
+++ b/vllm_dllm_plugin/runtime_scheduler.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""vLLM-facing scheduler adapter for Phase 4 runtime usage.
+
+This adapter keeps the existing helper scheduler logic as the source of
+contract checks while inheriting from the upstream vLLM scheduler class so the
+class is usable as ``--scheduler-cls`` when ``vllm`` is installed.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from vllm_dllm_plugin.scheduler import (
+    DllmRequestState,
+    DllmWorkerResult,
+)
+from vllm_dllm_plugin.scheduler import (
+    DllmScheduler as DllmSchedulerHelper,
+)
+
+try:
+    from vllm.v1.core.sched.scheduler import Scheduler as VllmScheduler
+    from vllm.v1.outputs import DraftTokenIds, ModelRunnerOutput
+
+    _VLLM_AVAILABLE = True
+except ImportError:  # pragma: no cover - exercised only in no-vLLM envs.
+    VllmScheduler = object  # type: ignore[assignment,misc]
+    DraftTokenIds = Any  # type: ignore[assignment]
+    ModelRunnerOutput = Any  # type: ignore[assignment]
+    _VLLM_AVAILABLE = False
+
+
+class DllmRuntimeScheduler(VllmScheduler):
+    """Runtime scheduler adapter meant for CLI ``--scheduler-cls`` usage."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        if not _VLLM_AVAILABLE:
+            raise RuntimeError(
+                "DllmRuntimeScheduler requires vLLM. Install with "
+                "`uv sync --group dev --extra vllm`.",
+            )
+        super().__init__(*args, **kwargs)
+        self._dllm_helper = DllmSchedulerHelper()
+
+    def add_request(self, request: Any) -> None:
+        """Ensure first-step dLLM draft block is initialized for new requests."""
+
+        super().add_request(request)
+        live_req = self.requests.get(request.request_id)
+        if live_req is None or live_req.spec_token_ids:
+            return
+        prompt = live_req.prompt_token_ids or []
+        live_req.spec_token_ids = list(
+            self._dllm_helper.initialize_first_block(prompt_token_ids=prompt),
+        )
+
+    def update_draft_token_ids(self, draft_token_ids: DraftTokenIds) -> None:
+        self._fail_if_structured_output_active(draft_token_ids.req_ids)
+        self._validate_draft_lengths(draft_token_ids)
+        super().update_draft_token_ids(draft_token_ids)
+
+    def update_draft_token_ids_in_output(
+        self,
+        draft_token_ids: DraftTokenIds,
+        scheduler_output: Any,
+    ) -> None:
+        self._fail_if_structured_output_active(draft_token_ids.req_ids)
+        self._validate_draft_lengths(draft_token_ids)
+        super().update_draft_token_ids_in_output(draft_token_ids, scheduler_output)
+
+    def update_from_output(
+        self,
+        scheduler_output: Any,
+        model_runner_output: ModelRunnerOutput,
+    ) -> dict[int, Any]:
+        """Validate dLLM scheduler-worker contract before delegating upstream."""
+
+        expected_req_ids = tuple(scheduler_output.num_scheduled_tokens.keys())
+        helper_states = {
+            req_id: DllmRequestState(
+                request_id=req_id,
+                # Use draft_size so helper accounting checks can run.
+                num_computed_tokens=self._dllm_helper.draft_size,
+            )
+            for req_id in expected_req_ids
+        }
+        helper_results = tuple(
+            DllmWorkerResult(
+                request_id=req_id,
+                sampled_token_ids=tuple(sampled_token_ids),
+            )
+            for req_id, sampled_token_ids in zip(
+                model_runner_output.req_ids,
+                model_runner_output.sampled_token_ids,
+                strict=True,
+            )
+        )
+        self._dllm_helper.update_from_output(
+            states=helper_states,
+            worker_results=helper_results,
+        )
+        return super().update_from_output(scheduler_output, model_runner_output)
+
+    def _validate_draft_lengths(self, draft_token_ids: DraftTokenIds) -> None:
+        for req_id, token_ids in zip(
+            draft_token_ids.req_ids,
+            draft_token_ids.draft_token_ids,
+            strict=True,
+        ):
+            if len(token_ids) != self._dllm_helper.draft_size:
+                raise ValueError(
+                    "draft token block length mismatch in DllmRuntimeScheduler: "
+                    f"request_id={req_id!r} expected={self._dllm_helper.draft_size} "
+                    f"got={len(token_ids)}",
+                )
+
+    def _fail_if_structured_output_active(self, req_ids: list[str]) -> None:
+        for req_id in req_ids:
+            request = self.requests.get(req_id)
+            if request is None:
+                continue
+            if self.structured_output_manager.should_advance(request):
+                raise ValueError(
+                    "structured-output grammar rewriting is not supported for dLLM "
+                    f"block mode (request_id={req_id!r})",
+                )
+
+
+__all__ = ["DllmRuntimeScheduler"]

--- a/vllm_dllm_plugin/runtime_worker.py
+++ b/vllm_dllm_plugin/runtime_worker.py
@@ -4,8 +4,10 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
+from vllm_dllm_plugin.config import DRAFT_SIZE, LLADA2_DEFAULT_MASK_TOKEN_ID
+from vllm_dllm_plugin.remasking import Llada2DefaultRemaskingPolicy
 from vllm_dllm_plugin.worker import DllmWorker as DllmWorkerHelper
 from vllm_dllm_plugin.worker import DllmWorkerStep
 
@@ -15,9 +17,61 @@ try:
 
     _VLLM_AVAILABLE = True
 except ImportError:  # pragma: no cover - exercised only in no-vLLM envs.
-    VllmGPUWorker = object  # type: ignore[assignment,misc]
-    DraftTokenIds = Any  # type: ignore[assignment]
+    VllmGPUWorker = object
+    DraftTokenIds = Any
     _VLLM_AVAILABLE = False
+
+
+def build_mock_block_logits(
+    *,
+    input_draft: list[int],
+    sampled_token_ids: list[int],
+    draft_size: int = DRAFT_SIZE,
+) -> list[list[float]]:
+    """Create deterministic block logits for remask handoff in mock mode."""
+
+    if len(input_draft) != draft_size:
+        raise ValueError(
+            "input_draft length must equal draft_size for mock logits: "
+            f"got {len(input_draft)} vs {draft_size}",
+        )
+    max_seen = max(
+        [LLADA2_DEFAULT_MASK_TOKEN_ID, *input_draft, *sampled_token_ids],
+    )
+    vocab_size = max(max_seen + 2, 256)
+    rows: list[list[float]] = []
+    for i in range(draft_size):
+        if i < len(sampled_token_ids):
+            target_id = sampled_token_ids[i]
+        else:
+            draft_tok = input_draft[i]
+            target_id = 0 if draft_tok == LLADA2_DEFAULT_MASK_TOKEN_ID else draft_tok
+        row = [0.0] * vocab_size
+        row[int(target_id)] = 1.0
+        rows.append(row)
+    return rows
+
+
+def run_block_contract_from_model_output(
+    *,
+    helper: DllmWorkerHelper,
+    request_id: str,
+    input_draft: list[int],
+    sampled_token_ids: list[int],
+) -> DllmWorkerStep:
+    """Apply one helper-level remask step using mock logits."""
+
+    logits = build_mock_block_logits(
+        input_draft=input_draft,
+        sampled_token_ids=sampled_token_ids,
+        draft_size=helper.draft_size,
+    )
+    return helper.run_one_block(
+        request_id=request_id,
+        input_draft=input_draft,
+        logits=logits,
+        policy=Llada2DefaultRemaskingPolicy(),
+    )
 
 
 class DllmRuntimeWorker(VllmGPUWorker):
@@ -33,9 +87,50 @@ class DllmRuntimeWorker(VllmGPUWorker):
         # Reuse helper to keep one source of truth for v2 requirement and draft
         # block shape validations.
         self._dllm_helper = DllmWorkerHelper(require_v2_model_runner=True)
+        self._dllm_last_draft_token_ids: DraftTokenIds | None = None
+
+    def execute_model(self, scheduler_output: Any) -> Any:
+        output = super().execute_model(scheduler_output)
+        # Only process concrete model outputs from last PP stage.
+        if output is None or not hasattr(output, "sampled_token_ids"):
+            return output
+
+        next_req_ids: list[str] = []
+        next_blocks: list[list[int]] = []
+        for idx, (req_id, sampled_token_ids) in enumerate(
+            zip(output.req_ids, output.sampled_token_ids, strict=True),
+        ):
+            input_draft = scheduler_output.scheduled_spec_decode_tokens.get(req_id)
+            if not input_draft:
+                continue
+            if len(input_draft) != self._dllm_helper.draft_size:
+                continue
+            step = run_block_contract_from_model_output(
+                helper=self._dllm_helper,
+                request_id=req_id,
+                input_draft=list(input_draft),
+                sampled_token_ids=list(sampled_token_ids),
+            )
+            output.sampled_token_ids[idx] = list(step.sampled_token_ids)
+            next_req_ids.append(req_id)
+            next_blocks.append(list(self._dllm_helper.take_draft_token_ids(step)))
+
+        self._dllm_last_draft_token_ids = (
+            cast(Any, DraftTokenIds)(
+                req_ids=next_req_ids,
+                draft_token_ids=next_blocks,
+            )
+            if next_req_ids
+            else None
+        )
+        return output
 
     def take_draft_token_ids(self) -> DraftTokenIds | None:
-        draft_token_ids = super().take_draft_token_ids()
+        draft_token_ids = self._dllm_last_draft_token_ids
+        if draft_token_ids is not None:
+            self._dllm_last_draft_token_ids = None
+        else:
+            draft_token_ids = super().take_draft_token_ids()
         if draft_token_ids is None:
             return None
         for req_id, next_block in zip(
@@ -53,4 +148,8 @@ class DllmRuntimeWorker(VllmGPUWorker):
         return draft_token_ids
 
 
-__all__ = ["DllmRuntimeWorker"]
+__all__ = [
+    "DllmRuntimeWorker",
+    "build_mock_block_logits",
+    "run_block_contract_from_model_output",
+]

--- a/vllm_dllm_plugin/runtime_worker.py
+++ b/vllm_dllm_plugin/runtime_worker.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""vLLM-facing worker adapter for Phase 4 runtime usage."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from vllm_dllm_plugin.worker import DllmWorker as DllmWorkerHelper
+from vllm_dllm_plugin.worker import DllmWorkerStep
+
+try:
+    from vllm.v1.outputs import DraftTokenIds
+    from vllm.v1.worker.gpu_worker import Worker as VllmGPUWorker
+
+    _VLLM_AVAILABLE = True
+except ImportError:  # pragma: no cover - exercised only in no-vLLM envs.
+    VllmGPUWorker = object  # type: ignore[assignment,misc]
+    DraftTokenIds = Any  # type: ignore[assignment]
+    _VLLM_AVAILABLE = False
+
+
+class DllmRuntimeWorker(VllmGPUWorker):
+    """Runtime worker adapter meant for CLI ``--worker-cls`` usage."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        if not _VLLM_AVAILABLE:
+            raise RuntimeError(
+                "DllmRuntimeWorker requires vLLM. Install with "
+                "`uv sync --group dev --extra vllm`.",
+            )
+        super().__init__(*args, **kwargs)
+        # Reuse helper to keep one source of truth for v2 requirement and draft
+        # block shape validations.
+        self._dllm_helper = DllmWorkerHelper(require_v2_model_runner=True)
+
+    def take_draft_token_ids(self) -> DraftTokenIds | None:
+        draft_token_ids = super().take_draft_token_ids()
+        if draft_token_ids is None:
+            return None
+        for req_id, next_block in zip(
+            draft_token_ids.req_ids,
+            draft_token_ids.draft_token_ids,
+            strict=True,
+        ):
+            self._dllm_helper.take_draft_token_ids(
+                DllmWorkerStep(
+                    request_id=req_id,
+                    sampled_token_ids=(),
+                    next_input_block=tuple(next_block),
+                ),
+            )
+        return draft_token_ids
+
+
+__all__ = ["DllmRuntimeWorker"]

--- a/vllm_dllm_plugin/runtime_worker.py
+++ b/vllm_dllm_plugin/runtime_worker.py
@@ -74,6 +74,57 @@ def run_block_contract_from_model_output(
     )
 
 
+def validate_runtime_input_draft(
+    *,
+    request_id: str,
+    input_draft: list[int] | None,
+    draft_size: int,
+) -> list[int]:
+    """Fail-fast validation for scheduler-provided draft blocks."""
+
+    if input_draft is None:
+        raise ValueError(
+            "missing scheduled_spec_decode_tokens for request in runtime worker: "
+            f"request_id={request_id!r}",
+        )
+    if len(input_draft) != draft_size:
+        raise ValueError(
+            "malformed scheduled_spec_decode_tokens length in runtime worker: "
+            f"request_id={request_id!r} expected={draft_size} got={len(input_draft)}",
+        )
+    return input_draft
+
+
+def validate_runtime_draft_handoff_coverage(
+    *,
+    expected_req_ids: set[str],
+    produced_req_ids: list[str],
+) -> None:
+    """Ensure next-step draft handoff covers exactly the expected requests."""
+
+    seen: set[str] = set()
+    duplicate: set[str] = set()
+    for req_id in produced_req_ids:
+        if req_id in seen:
+            duplicate.add(req_id)
+        seen.add(req_id)
+    if duplicate:
+        raise ValueError(
+            "duplicate request_id values in runtime draft handoff: "
+            f"{sorted(duplicate)}",
+        )
+    missing = sorted(expected_req_ids.difference(seen))
+    if missing:
+        raise ValueError(
+            f"missing request_id values in runtime draft handoff: {missing}",
+        )
+    unexpected = sorted(seen.difference(expected_req_ids))
+    if unexpected:
+        raise ValueError(
+            f"unexpected request_id values in runtime draft handoff: {unexpected}",
+        )
+
+
 class DllmRuntimeWorker(VllmGPUWorker):
     """Runtime worker adapter meant for CLI ``--worker-cls`` usage."""
 
@@ -88,6 +139,7 @@ class DllmRuntimeWorker(VllmGPUWorker):
         # block shape validations.
         self._dllm_helper = DllmWorkerHelper(require_v2_model_runner=True)
         self._dllm_last_draft_token_ids: DraftTokenIds | None = None
+        self._dllm_expected_draft_req_ids: set[str] | None = None
 
     def execute_model(self, scheduler_output: Any) -> Any:
         output = super().execute_model(scheduler_output)
@@ -95,16 +147,17 @@ class DllmRuntimeWorker(VllmGPUWorker):
         if output is None or not hasattr(output, "sampled_token_ids"):
             return output
 
+        expected_req_ids = set(output.req_ids)
         next_req_ids: list[str] = []
         next_blocks: list[list[int]] = []
         for idx, (req_id, sampled_token_ids) in enumerate(
             zip(output.req_ids, output.sampled_token_ids, strict=True),
         ):
-            input_draft = scheduler_output.scheduled_spec_decode_tokens.get(req_id)
-            if not input_draft:
-                continue
-            if len(input_draft) != self._dllm_helper.draft_size:
-                continue
+            input_draft = validate_runtime_input_draft(
+                request_id=req_id,
+                input_draft=scheduler_output.scheduled_spec_decode_tokens.get(req_id),
+                draft_size=self._dllm_helper.draft_size,
+            )
             step = run_block_contract_from_model_output(
                 helper=self._dllm_helper,
                 request_id=req_id,
@@ -115,6 +168,11 @@ class DllmRuntimeWorker(VllmGPUWorker):
             next_req_ids.append(req_id)
             next_blocks.append(list(self._dllm_helper.take_draft_token_ids(step)))
 
+        validate_runtime_draft_handoff_coverage(
+            expected_req_ids=expected_req_ids,
+            produced_req_ids=next_req_ids,
+        )
+        self._dllm_expected_draft_req_ids = expected_req_ids
         self._dllm_last_draft_token_ids = (
             cast(Any, DraftTokenIds)(
                 req_ids=next_req_ids,
@@ -133,6 +191,13 @@ class DllmRuntimeWorker(VllmGPUWorker):
             draft_token_ids = super().take_draft_token_ids()
         if draft_token_ids is None:
             return None
+        expected_req_ids = self._dllm_expected_draft_req_ids
+        if expected_req_ids is not None:
+            validate_runtime_draft_handoff_coverage(
+                expected_req_ids=expected_req_ids,
+                produced_req_ids=list(draft_token_ids.req_ids),
+            )
+            self._dllm_expected_draft_req_ids = None
         for req_id, next_block in zip(
             draft_token_ids.req_ids,
             draft_token_ids.draft_token_ids,
@@ -152,4 +217,6 @@ __all__ = [
     "DllmRuntimeWorker",
     "build_mock_block_logits",
     "run_block_contract_from_model_output",
+    "validate_runtime_draft_handoff_coverage",
+    "validate_runtime_input_draft",
 ]

--- a/vllm_dllm_plugin/scheduler.py
+++ b/vllm_dllm_plugin/scheduler.py
@@ -1,0 +1,205 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Phase 4 scheduler semantics for dLLM block decode.
+
+This module models the scheduler-side contract in ``docs/DESIGN_MVP.md`` and
+``docs/CONTRACTS.md`` without forcing a hard runtime dependency on vLLM types.
+
+Key invariants:
+- ``spec_token_ids`` holds the next-step input block (length ``DRAFT_SIZE``).
+- One decode schedule emits exactly ``DRAFT_SIZE`` draft tokens per request.
+- Commit-0 rollback subtracts scheduled tokens when a step commits no tokens.
+- Grammar-constrained draft rewriting is explicitly unsupported for dLLM blocks
+  in this MVP path; callers get a hard error instead of silent corruption.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from vllm_dllm_plugin.config import DRAFT_SIZE, LLADA2_DEFAULT_MASK_TOKEN_ID
+
+
+@dataclass(slots=True)
+class DllmRequestState:
+    """Minimal per-request state used by :class:`DllmScheduler`."""
+
+    request_id: str
+    num_computed_tokens: int = 0
+    spec_token_ids: tuple[int, ...] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class DllmScheduledRequest:
+    """One scheduled block for a single request."""
+
+    request_id: str
+    scheduled_spec_decode_tokens: tuple[int, ...]
+    num_scheduled_tokens: int
+
+
+@dataclass(frozen=True, slots=True)
+class DllmSchedulerOutput:
+    """Block-schedule output for one scheduler step."""
+
+    requests: tuple[DllmScheduledRequest, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class DllmWorkerResult:
+    """Scheduler-relevant subset of worker/model output."""
+
+    request_id: str
+    sampled_token_ids: tuple[int, ...]
+
+
+class DllmScheduler:
+    """Scheduler helper implementing issue #8 + issue #9 behavior."""
+
+    def __init__(
+        self,
+        *,
+        draft_size: int = DRAFT_SIZE,
+        mask_token_id: int = LLADA2_DEFAULT_MASK_TOKEN_ID,
+    ) -> None:
+        if draft_size <= 0:
+            raise ValueError("draft_size must be positive")
+        self.draft_size = int(draft_size)
+        self.mask_token_id = int(mask_token_id)
+
+    def initialize_first_block(
+        self,
+        *,
+        prompt_token_ids: Sequence[int],
+    ) -> tuple[int, ...]:
+        """Return a deterministic first block from prompt suffix + mask padding."""
+
+        tail = tuple(int(tok) for tok in prompt_token_ids[-self.draft_size :])
+        if len(tail) < self.draft_size:
+            pad = (self.mask_token_id,) * (self.draft_size - len(tail))
+            tail = tail + pad
+        return tail
+
+    def ensure_spec_token_ids(
+        self,
+        state: DllmRequestState,
+        *,
+        prompt_token_ids: Sequence[int],
+    ) -> tuple[int, ...]:
+        """Initialize ``state.spec_token_ids`` if missing and return the block."""
+
+        if state.spec_token_ids is None:
+            state.spec_token_ids = self.initialize_first_block(
+                prompt_token_ids=prompt_token_ids,
+            )
+        self._validate_block(state.spec_token_ids, field_name="spec_token_ids")
+        return state.spec_token_ids
+
+    def schedule_decode_step(
+        self,
+        requests: Sequence[tuple[DllmRequestState, Sequence[int]]],
+    ) -> DllmSchedulerOutput:
+        """Schedule one block for each request.
+
+        Args:
+            requests: Sequence of ``(request_state, prompt_token_ids)`` entries.
+                ``prompt_token_ids`` is used only when ``spec_token_ids`` needs
+                first-block initialization.
+        """
+
+        scheduled: list[DllmScheduledRequest] = []
+        for state, prompt in requests:
+            block = self.ensure_spec_token_ids(state, prompt_token_ids=prompt)
+            scheduled.append(
+                DllmScheduledRequest(
+                    request_id=state.request_id,
+                    scheduled_spec_decode_tokens=block,
+                    num_scheduled_tokens=self.draft_size,
+                ),
+            )
+            state.num_computed_tokens += self.draft_size
+        return DllmSchedulerOutput(requests=tuple(scheduled))
+
+    def update_from_output(
+        self,
+        *,
+        states: dict[str, DllmRequestState],
+        worker_results: Sequence[DllmWorkerResult],
+    ) -> None:
+        """Apply commit accounting with commit-0 rollback."""
+
+        for result in worker_results:
+            state = states[result.request_id]
+            committed = len(result.sampled_token_ids)
+            if committed == 0:
+                # Commit-0 rollback: this step contributed no finalized tokens.
+                state.num_computed_tokens -= self.draft_size
+            if state.num_computed_tokens < 0:
+                state.num_computed_tokens = 0
+
+    def update_draft_token_ids(
+        self,
+        *,
+        state: DllmRequestState,
+        next_input_block: Sequence[int],
+        grammar_constrained: bool = False,
+    ) -> None:
+        """Store the next block; grammar-mutating mode is disallowed in MVP."""
+
+        if grammar_constrained:
+            raise ValueError(
+                "dLLM block drafts are incompatible with AR draft grammar rewriting; "
+                "structured-output grammar constraints are out of MVP scope.",
+            )
+        state.spec_token_ids = self._normalize_block(next_input_block)
+
+    def update_draft_token_ids_in_output(
+        self,
+        *,
+        output: DllmSchedulerOutput,
+        next_blocks_by_request_id: dict[str, Sequence[int]],
+        grammar_constrained: bool = False,
+    ) -> DllmSchedulerOutput:
+        """Return a new scheduler output with draft updates applied safely."""
+
+        if grammar_constrained:
+            raise ValueError(
+                "dLLM block drafts are incompatible with AR draft grammar rewriting; "
+                "structured-output grammar constraints are out of MVP scope.",
+            )
+        updated: list[DllmScheduledRequest] = []
+        for req in output.requests:
+            if req.request_id in next_blocks_by_request_id:
+                block = self._normalize_block(next_blocks_by_request_id[req.request_id])
+            else:
+                block = req.scheduled_spec_decode_tokens
+            updated.append(
+                DllmScheduledRequest(
+                    request_id=req.request_id,
+                    scheduled_spec_decode_tokens=block,
+                    num_scheduled_tokens=self.draft_size,
+                ),
+            )
+        return DllmSchedulerOutput(requests=tuple(updated))
+
+    def _normalize_block(self, token_ids: Sequence[int]) -> tuple[int, ...]:
+        block = tuple(int(tok) for tok in token_ids)
+        self._validate_block(block, field_name="block")
+        return block
+
+    def _validate_block(self, block: Sequence[int], *, field_name: str) -> None:
+        if len(block) != self.draft_size:
+            raise ValueError(
+                f"{field_name} length must be draft_size={self.draft_size}, "
+                f"got {len(block)}",
+            )
+
+
+__all__ = [
+    "DllmRequestState",
+    "DllmScheduledRequest",
+    "DllmScheduler",
+    "DllmSchedulerOutput",
+    "DllmWorkerResult",
+]

--- a/vllm_dllm_plugin/scheduler.py
+++ b/vllm_dllm_plugin/scheduler.py
@@ -57,15 +57,8 @@ class DllmWorkerResult:
 class DllmScheduler:
     """Scheduler helper implementing issue #8 + issue #9 behavior."""
 
-    def __init__(
-        self,
-        *,
-        draft_size: int = DRAFT_SIZE,
-        mask_token_id: int = LLADA2_DEFAULT_MASK_TOKEN_ID,
-    ) -> None:
-        if draft_size <= 0:
-            raise ValueError("draft_size must be positive")
-        self.draft_size = int(draft_size)
+    def __init__(self, *, mask_token_id: int = LLADA2_DEFAULT_MASK_TOKEN_ID) -> None:
+        self.draft_size = DRAFT_SIZE
         self.mask_token_id = int(mask_token_id)
 
     def initialize_first_block(
@@ -130,8 +123,21 @@ class DllmScheduler:
         """Apply commit accounting with commit-0 rollback."""
 
         for result in worker_results:
+            if result.request_id not in states:
+                raise ValueError(
+                    "worker result contains unknown request_id "
+                    f"{result.request_id!r}; ensure scheduler and worker outputs "
+                    "are synchronized before update_from_output()",
+                )
             state = states[result.request_id]
             committed = len(result.sampled_token_ids)
+            if committed > self.draft_size:
+                raise ValueError(
+                    "sampled_token_ids length exceeds draft_size in "
+                    "update_from_output: "
+                    f"request_id={result.request_id!r} committed={committed} "
+                    f"draft_size={self.draft_size}",
+                )
             if committed == 0:
                 # Commit-0 rollback: this step contributed no finalized tokens.
                 state.num_computed_tokens -= self.draft_size

--- a/vllm_dllm_plugin/scheduler.py
+++ b/vllm_dllm_plugin/scheduler.py
@@ -8,7 +8,8 @@ This module models the scheduler-side contract in ``docs/DESIGN_MVP.md`` and
 Key invariants:
 - ``spec_token_ids`` holds the next-step input block (length ``DRAFT_SIZE``).
 - One decode schedule emits exactly ``DRAFT_SIZE`` draft tokens per request.
-- Commit-0 rollback subtracts scheduled tokens when a step commits no tokens.
+- Post-step accounting subtracts rejected positions so ``num_computed_tokens``
+  tracks committed progress (including full commit-0 rollback).
 - Grammar-constrained draft rewriting is explicitly unsupported for dLLM blocks
   in this MVP path; callers get a hard error instead of silent corruption.
 """
@@ -120,8 +121,9 @@ class DllmScheduler:
         states: dict[str, DllmRequestState],
         worker_results: Sequence[DllmWorkerResult],
     ) -> None:
-        """Apply commit accounting with commit-0 rollback."""
+        """Apply commit accounting with rejection rollback."""
 
+        seen_request_ids: set[str] = set()
         for result in worker_results:
             if result.request_id not in states:
                 raise ValueError(
@@ -129,6 +131,12 @@ class DllmScheduler:
                     f"{result.request_id!r}; ensure scheduler and worker outputs "
                     "are synchronized before update_from_output()",
                 )
+            if result.request_id in seen_request_ids:
+                raise ValueError(
+                    "duplicate request_id in worker results for one scheduler step: "
+                    f"{result.request_id!r}",
+                )
+            seen_request_ids.add(result.request_id)
             state = states[result.request_id]
             committed = len(result.sampled_token_ids)
             if committed > self.draft_size:
@@ -138,9 +146,10 @@ class DllmScheduler:
                     f"request_id={result.request_id!r} committed={committed} "
                     f"draft_size={self.draft_size}",
                 )
-            if committed == 0:
-                # Commit-0 rollback: this step contributed no finalized tokens.
-                state.num_computed_tokens -= self.draft_size
+            # Roll back rejected positions; when committed == 0 this is a full
+            # commit-0 rollback, and when committed > 0 this keeps accounting
+            # aligned with effective committed progress.
+            state.num_computed_tokens -= self.draft_size - committed
             if state.num_computed_tokens < 0:
                 state.num_computed_tokens = 0
 

--- a/vllm_dllm_plugin/scheduler.py
+++ b/vllm_dllm_plugin/scheduler.py
@@ -123,6 +123,25 @@ class DllmScheduler:
     ) -> None:
         """Apply commit accounting with rejection rollback."""
 
+        state_request_ids = set(states)
+        worker_request_ids = [result.request_id for result in worker_results]
+        unknown_request_ids = sorted(
+            set(worker_request_ids).difference(state_request_ids),
+        )
+        if unknown_request_ids:
+            raise ValueError(
+                "worker result contains unknown request_id values in "
+                "update_from_output(): "
+                f"{unknown_request_ids}",
+            )
+        missing_request_ids = sorted(state_request_ids.difference(worker_request_ids))
+        if missing_request_ids:
+            raise ValueError(
+                "missing worker results for scheduled request_ids in "
+                "update_from_output(): "
+                f"{missing_request_ids}",
+            )
+
         seen_request_ids: set[str] = set()
         for result in worker_results:
             if result.request_id not in states:

--- a/vllm_dllm_plugin/worker.py
+++ b/vllm_dllm_plugin/worker.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Phase 4 worker helpers for one-block dLLM execution.
+
+This module keeps the worker/scheduler contract explicit while remaining usable
+in dev environments that do not install ``vllm`` (optional dependency).
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from vllm_dllm_plugin.remasking import RemaskingPolicy, remask_after_block_forward
+from vllm_dllm_plugin.scheduler import DllmWorkerResult
+
+
+def is_v2_model_runner_enabled() -> bool:
+    """Return ``True`` when ``VLLM_USE_V2_MODEL_RUNNER`` is enabled."""
+
+    value = os.environ.get("VLLM_USE_V2_MODEL_RUNNER", "")
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+@dataclass(frozen=True, slots=True)
+class DllmWorkerStep:
+    """Result of one block forward + remask handoff for one request."""
+
+    request_id: str
+    sampled_token_ids: tuple[int, ...]
+    next_input_block: tuple[int, ...]
+
+
+class DllmWorker:
+    """Thin worker façade aligned with issue #10's one-block contract."""
+
+    def __init__(self, *, require_v2_model_runner: bool = True) -> None:
+        self.require_v2_model_runner = require_v2_model_runner
+        self.v2_model_runner_enabled = is_v2_model_runner_enabled()
+        if self.require_v2_model_runner and not self.v2_model_runner_enabled:
+            raise RuntimeError(
+                "DllmWorker requires VLLM_USE_V2_MODEL_RUNNER=1 for MVP Phase 4.",
+            )
+
+    def run_one_block(
+        self,
+        *,
+        request_id: str,
+        input_draft: Sequence[int],
+        logits: Any,
+        policy: RemaskingPolicy,
+        remasking_config: Mapping[str, Any] | None = None,
+    ) -> DllmWorkerStep:
+        """Execute one dLLM block and map remask output to worker fields."""
+
+        result = remask_after_block_forward(
+            input_draft=input_draft,
+            logits=logits,
+            policy=policy,
+            remasking_config=remasking_config,
+        )
+        return DllmWorkerStep(
+            request_id=request_id,
+            sampled_token_ids=tuple(int(tok) for tok in result.committed_token_ids),
+            next_input_block=tuple(int(tok) for tok in result.next_input_block),
+        )
+
+    def take_draft_token_ids(self, step: DllmWorkerStep) -> tuple[int, ...]:
+        """Return the next draft block for scheduler ``update_draft_token_ids``."""
+
+        return step.next_input_block
+
+    def as_scheduler_result(self, step: DllmWorkerStep) -> DllmWorkerResult:
+        """Convert worker output to scheduler accounting payload."""
+
+        return DllmWorkerResult(
+            request_id=step.request_id,
+            sampled_token_ids=step.sampled_token_ids,
+        )
+
+
+__all__ = [
+    "DllmWorker",
+    "DllmWorkerStep",
+    "is_v2_model_runner_enabled",
+]

--- a/vllm_dllm_plugin/worker.py
+++ b/vllm_dllm_plugin/worker.py
@@ -13,6 +13,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
 
+from vllm_dllm_plugin.config import DRAFT_SIZE
 from vllm_dllm_plugin.remasking import RemaskingPolicy, remask_after_block_forward
 from vllm_dllm_plugin.scheduler import DllmWorkerResult
 
@@ -37,6 +38,7 @@ class DllmWorker:
     """Thin worker façade aligned with issue #10's one-block contract."""
 
     def __init__(self, *, require_v2_model_runner: bool = True) -> None:
+        self.draft_size = DRAFT_SIZE
         self.require_v2_model_runner = require_v2_model_runner
         self.v2_model_runner_enabled = is_v2_model_runner_enabled()
         if self.require_v2_model_runner and not self.v2_model_runner_enabled:
@@ -60,6 +62,7 @@ class DllmWorker:
             logits=logits,
             policy=policy,
             remasking_config=remasking_config,
+            draft_size=self.draft_size,
         )
         return DllmWorkerStep(
             request_id=request_id,
@@ -70,6 +73,11 @@ class DllmWorker:
     def take_draft_token_ids(self, step: DllmWorkerStep) -> tuple[int, ...]:
         """Return the next draft block for scheduler ``update_draft_token_ids``."""
 
+        if len(step.next_input_block) != self.draft_size:
+            raise ValueError(
+                "next_input_block length mismatch in take_draft_token_ids: "
+                f"expected {self.draft_size}, got {len(step.next_input_block)}",
+            )
         return step.next_input_block
 
     def as_scheduler_result(self, step: DllmWorkerStep) -> DllmWorkerResult:


### PR DESCRIPTION
## Summary
- add `DllmScheduler` helper semantics for first-block `spec_token_ids` initialization, fixed `DRAFT_SIZE` scheduling, grammar-safe draft handling, and commit/rejection accounting guardrails
- add `DllmWorker` helper semantics for one-block remask handoff (`run_one_block`, `take_draft_token_ids`) with explicit `VLLM_USE_V2_MODEL_RUNNER=1` expectation and scheduler-result mapping
- add **runtime adapter classes** for CLI override wiring: `DllmRuntimeScheduler` and `DllmRuntimeWorker`, delegating contract checks to the helper layer while inheriting vLLM runtime interfaces
- add regression tests for scheduler/worker contracts (unknown/duplicate/missing result coverage), adapter availability/typing behavior, and README updates for current Phase 4 state

## Test plan
- [x] `uv run ruff check .`
- [x] `uv run pytest`
- [x] `VLLM_USE_V2_MODEL_RUNNER=1 uv run python -c "from vllm_dllm_plugin.runtime_scheduler import DllmRuntimeScheduler; from vllm_dllm_plugin.runtime_worker import DllmRuntimeWorker; print('runtime-adapter-import-ok')"`

## Scope notes
- Closes #8, #9, #10 (Phase 4)
- Out of scope: full structured-output grammar product behavior, custom CUDA kernels, and Phase 7 real-model integration
- Phase 6 integration-confidence work (`#14/#16/#17`) remains separate
- Known Phase 4 caveat: runtime remasking currently bridges from synthesized logits for mock-stack contract coverage; follow-up tracked in #31
- Additional runtime-adapter integration smoke coverage against concrete vLLM runtime objects is tracked in #32

Made with [Cursor](https://cursor.com)